### PR TITLE
fix: recreate resource if object the manually deleted

### DIFF
--- a/resource_dns_record.go
+++ b/resource_dns_record.go
@@ -148,9 +148,19 @@ func resourceFreeIPADNSDNSRecordRead(ctx context.Context, d *schema.ResourceData
 	}
 
 	res, err := client.DnsrecordShow(&args, &optArgs)
+
 	if err != nil {
-		return diag.Errorf("Error creating freeipa dns record: %s", err)
+		if strings.Contains(err.Error(), "NotFound") {
+			d.SetId("")
+			log.Printf("[DEBUG] DNS record not found")
+			return nil
+		} else {
+			return diag.Errorf("Error reading freeipa DNS record: %s", err)
+		}
 	}
+	// if err != nil {
+	// 	return diag.Errorf("Error creating freeipa dns record: %s", err)
+	// }
 
 	_type := d.Get("type")
 

--- a/resource_dns_record.go
+++ b/resource_dns_record.go
@@ -148,7 +148,6 @@ func resourceFreeIPADNSDNSRecordRead(ctx context.Context, d *schema.ResourceData
 	}
 
 	res, err := client.DnsrecordShow(&args, &optArgs)
-
 	if err != nil {
 		if strings.Contains(err.Error(), "NotFound") {
 			d.SetId("")
@@ -158,10 +157,6 @@ func resourceFreeIPADNSDNSRecordRead(ctx context.Context, d *schema.ResourceData
 			return diag.Errorf("Error reading freeipa DNS record: %s", err)
 		}
 	}
-	// if err != nil {
-	// 	return diag.Errorf("Error creating freeipa dns record: %s", err)
-	// }
-
 	_type := d.Get("type")
 
 	switch _type {

--- a/resource_dns_zone.go
+++ b/resource_dns_zone.go
@@ -266,7 +266,13 @@ func resourceFreeIPADNSDNSZoneRead(ctx context.Context, d *schema.ResourceData, 
 	res, err := client.DnszoneShow(&ipa.DnszoneShowArgs{}, &optArgs)
 
 	if err != nil {
-		return diag.Errorf("Error show freeipa dns zone: %s", err)
+		if strings.Contains(err.Error(), "NotFound") {
+			d.SetId("")
+			log.Printf("[DEBUG] DNS Zone not found")
+			return nil
+		} else {
+			return diag.Errorf("Error reading freeipa DNS zone: %s", err)
+		}
 	}
 
 	d.Set("disable_zone", !*res.Result.Idnszoneactive)

--- a/resource_dns_zone.go
+++ b/resource_dns_zone.go
@@ -264,7 +264,6 @@ func resourceFreeIPADNSDNSZoneRead(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	res, err := client.DnszoneShow(&ipa.DnszoneShowArgs{}, &optArgs)
-
 	if err != nil {
 		if strings.Contains(err.Error(), "NotFound") {
 			d.SetId("")

--- a/resource_group.go
+++ b/resource_group.go
@@ -91,7 +91,7 @@ func resourceFreeIPADNSGroupCreate(ctx context.Context, d *schema.ResourceData, 
 }
 
 func resourceFreeIPADNSGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] Read freeipa grupe")
+	log.Printf("[DEBUG] Read freeipa group")
 
 	client, err := meta.(*Config).Client()
 	if err != nil {
@@ -107,13 +107,20 @@ func resourceFreeIPADNSGroupRead(ctx context.Context, d *schema.ResourceData, me
 		Cn: d.Id(),
 	}
 
+	log.Printf("[DEBUG] Read freeipa group %s", d.Id())
 	res, err := client.GroupShow(&args, &optArgs)
 
 	if err != nil {
-		return diag.Errorf("Error show freeipa grupe: %s", err)
+		if strings.Contains(err.Error(), "NotFound") {
+			d.SetId("")
+			log.Printf("[DEBUG] Group not found")
+			return nil
+		} else {
+			return diag.Errorf("Error reading freeipa group: %s", err)
+		}
 	}
 
-	log.Printf("[DEBUG] Read freeipa grupe %s", res.Result.Cn)
+	log.Printf("[DEBUG] Read freeipa group %s", res.Result.Cn)
 	return nil
 }
 
@@ -164,7 +171,7 @@ func resourceFreeIPADNSGroupUpdate(ctx context.Context, d *schema.ResourceData, 
 			if strings.Contains(err.Error(), "EmptyModlist") {
 				log.Printf("[DEBUG] EmptyModlist (4202): no modifications to be performed")
 			} else {
-				return diag.Errorf("Error update freeipa groupe: %s", err)
+				return diag.Errorf("Error update freeipa group: %s", err)
 			}
 		}
 	}
@@ -175,7 +182,7 @@ func resourceFreeIPADNSGroupUpdate(ctx context.Context, d *schema.ResourceData, 
 }
 
 func resourceFreeIPADNSGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] Delete freeipa grupe")
+	log.Printf("[DEBUG] Delete freeipa group")
 
 	client, err := meta.(*Config).Client()
 	if err != nil {
@@ -186,7 +193,7 @@ func resourceFreeIPADNSGroupDelete(ctx context.Context, d *schema.ResourceData, 
 	}
 	_, err = client.GroupDel(&args, &ipa.GroupDelOptionalArgs{})
 	if err != nil {
-		return diag.Errorf("Error delete freeipa grupe: %s", err)
+		return diag.Errorf("Error delete freeipa group: %s", err)
 	}
 
 	d.SetId("")

--- a/resource_group.go
+++ b/resource_group.go
@@ -109,7 +109,6 @@ func resourceFreeIPADNSGroupRead(ctx context.Context, d *schema.ResourceData, me
 
 	log.Printf("[DEBUG] Read freeipa group %s", d.Id())
 	res, err := client.GroupShow(&args, &optArgs)
-
 	if err != nil {
 		if strings.Contains(err.Error(), "NotFound") {
 			d.SetId("")

--- a/resource_hbac_policy.go
+++ b/resource_hbac_policy.go
@@ -118,7 +118,6 @@ func resourceFreeIPADNSHBACPolicyRead(ctx context.Context, d *schema.ResourceDat
 	}
 
 	res, err := client.HbacruleShow(&args, &optArgs)
-
 	if err != nil {
 		if strings.Contains(err.Error(), "NotFound") {
 			d.SetId("")

--- a/resource_hbac_policy.go
+++ b/resource_hbac_policy.go
@@ -120,7 +120,13 @@ func resourceFreeIPADNSHBACPolicyRead(ctx context.Context, d *schema.ResourceDat
 	res, err := client.HbacruleShow(&args, &optArgs)
 
 	if err != nil {
-		return diag.Errorf("Error show freeipa HBAC policy: %s", err)
+		if strings.Contains(err.Error(), "NotFound") {
+			d.SetId("")
+			log.Printf("[DEBUG] HBAC policy not found")
+			return nil
+		} else {
+			return diag.Errorf("Error reading freeipa HBAC policy: %s", err)
+		}
 	}
 
 	log.Printf("[DEBUG] Read freeipa HBAC policy %s", res.Result.Cn)

--- a/resource_hbac_policy_service_membership.go
+++ b/resource_hbac_policy_service_membership.go
@@ -103,7 +103,6 @@ func resourceFreeIPADNSHBACPolicyServiceMembershipRead(ctx context.Context, d *s
 		All: &all,
 	}
 	res, err := client.HbacruleShow(&args, &optArgs)
-
 	if err != nil {
 		if strings.Contains(err.Error(), "NotFound") {
 			d.Set("service", "")

--- a/resource_hbac_policy_service_membership.go
+++ b/resource_hbac_policy_service_membership.go
@@ -103,8 +103,17 @@ func resourceFreeIPADNSHBACPolicyServiceMembershipRead(ctx context.Context, d *s
 		All: &all,
 	}
 	res, err := client.HbacruleShow(&args, &optArgs)
+
 	if err != nil {
-		return diag.Errorf("Error show freeipa HBAC policy host membership: %s", err)
+		if strings.Contains(err.Error(), "NotFound") {
+			d.Set("service", "")
+			d.Set("servicegroup", "")
+			d.SetId("")
+			log.Printf("[DEBUG] HBAC policy not found")
+			return nil
+		} else {
+			return diag.Errorf("Error reading freeipa HBAC policy: %s", err)
+		}
 	}
 
 	switch typeId {
@@ -114,7 +123,7 @@ func resourceFreeIPADNSHBACPolicyServiceMembershipRead(ctx context.Context, d *s
 			d.Set("service", "")
 			d.Set("servicegroup", "")
 			d.SetId("")
-			return diag.Errorf("Error configuring freeipa HBAC policy, servicegroup not assigned: %s", svcId)
+			return nil
 		}
 	case "s":
 		if res.Result.MemberserviceHbacsvc == nil || !slices.Contains(*res.Result.MemberserviceHbacsvc, svcId) {
@@ -122,7 +131,7 @@ func resourceFreeIPADNSHBACPolicyServiceMembershipRead(ctx context.Context, d *s
 			d.Set("service", "")
 			d.Set("servicegroup", "")
 			d.SetId("")
-			return diag.Errorf("Error configuring freeipa HBAC policy, service not assigned: %s", svcId)
+			return nil
 		}
 	}
 

--- a/resource_host.go
+++ b/resource_host.go
@@ -216,7 +216,6 @@ func resourceFreeIPADNSHostRead(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	res, err := client.HostShow(&args, &optArgs)
-
 	if err != nil {
 		if strings.Contains(err.Error(), "NotFound") {
 			d.SetId("")

--- a/resource_host.go
+++ b/resource_host.go
@@ -218,7 +218,13 @@ func resourceFreeIPADNSHostRead(ctx context.Context, d *schema.ResourceData, met
 	res, err := client.HostShow(&args, &optArgs)
 
 	if err != nil {
-		return diag.Errorf("Error show freeipa host: %s", err)
+		if strings.Contains(err.Error(), "NotFound") {
+			d.SetId("")
+			log.Printf("[DEBUG] Host not found")
+			return nil
+		} else {
+			return diag.Errorf("Error reading freeipa host: %s", err)
+		}
 	}
 
 	log.Printf("[DEBUG] Read freeipa host %s", res.Result.Fqdn)

--- a/resource_host_hostgroup_membership.go
+++ b/resource_host_hostgroup_membership.go
@@ -118,9 +118,10 @@ func resourceFreeIPAHostHostGroupMembershipRead(ctx context.Context, d *schema.R
 	}
 
 	if strings.Contains(*res.Summary, "0 groups matched") {
-		log.Printf("[DEBUG] Warning! Group or User membership not exist")
+		log.Printf("[DEBUG] Warning! Hostgroup or Host membership not exist")
 		d.Set("host", "")
 		d.Set("hostgroup", "")
+		d.SetId("")
 	}
 
 	return nil
@@ -157,9 +158,14 @@ func resourceFreeIPAHostHostGroupMembershipDelete(ctx context.Context, d *schema
 
 	_, err = client.HostgroupRemoveMember(&args, &optArgs)
 	if err != nil {
-		return diag.Errorf("Error delete freeipa the host group membership: %s", err)
+		if strings.Contains(err.Error(), "NotFound") {
+			d.SetId("")
+			log.Printf("[DEBUG] Hostgroup not found")
+			return nil
+		} else {
+			return diag.Errorf("Error delete freeipa the host group membership: %s", err)
+		}
 	}
-
 	d.SetId("")
 
 	return nil

--- a/resource_hostgroup.go
+++ b/resource_hostgroup.go
@@ -82,7 +82,13 @@ func resourceFreeIPADNSHostGroupRead(ctx context.Context, d *schema.ResourceData
 	res, err := client.HostgroupShow(&args, &optArgs)
 
 	if err != nil {
-		return diag.Errorf("Error show freeipa hostgroup: %s", err)
+		if strings.Contains(err.Error(), "NotFound") {
+			d.SetId("")
+			log.Printf("[DEBUG] Hostgroup not found")
+			return nil
+		} else {
+			return diag.Errorf("Error reading freeipa hostgroup: %s", err)
+		}
 	}
 
 	log.Printf("[DEBUG] Read freeipa hostgroup %s", res.Result.Cn)

--- a/resource_hostgroup.go
+++ b/resource_hostgroup.go
@@ -80,7 +80,6 @@ func resourceFreeIPADNSHostGroupRead(ctx context.Context, d *schema.ResourceData
 	}
 
 	res, err := client.HostgroupShow(&args, &optArgs)
-
 	if err != nil {
 		if strings.Contains(err.Error(), "NotFound") {
 			d.SetId("")

--- a/resource_sudo_cmd.go
+++ b/resource_sudo_cmd.go
@@ -79,7 +79,6 @@ func resourceFreeIPASudocmdRead(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	res, err := client.SudocmdShow(&args, &optArgs)
-
 	if err != nil {
 		if strings.Contains(err.Error(), "NotFound") {
 			d.SetId("")

--- a/resource_sudo_cmd.go
+++ b/resource_sudo_cmd.go
@@ -81,7 +81,13 @@ func resourceFreeIPASudocmdRead(ctx context.Context, d *schema.ResourceData, met
 	res, err := client.SudocmdShow(&args, &optArgs)
 
 	if err != nil {
-		return diag.Errorf("Error show freeipa sudo command: %s", err)
+		if strings.Contains(err.Error(), "NotFound") {
+			d.SetId("")
+			log.Printf("[DEBUG] Sudo command not found")
+			return nil
+		} else {
+			return diag.Errorf("Error reading freeipa Sudo command: %s", err)
+		}
 	}
 
 	log.Printf("[DEBUG] Read freeipa sudo command %s", res.Result.Sudocmd)

--- a/resource_sudo_cmdgroup.go
+++ b/resource_sudo_cmdgroup.go
@@ -81,7 +81,13 @@ func resourceFreeIPASudocmdgroupRead(ctx context.Context, d *schema.ResourceData
 	res, err := client.SudocmdgroupShow(&args, &optArgs)
 
 	if err != nil {
-		return diag.Errorf("Error show freeipa sudo command group: %s", err)
+		if strings.Contains(err.Error(), "NotFound") {
+			d.SetId("")
+			log.Printf("[DEBUG] Sudo command group not found")
+			return nil
+		} else {
+			return diag.Errorf("Error reading freeipa sudo command group: %s", err)
+		}
 	}
 
 	log.Printf("[DEBUG] Read freeipa sudo command group %s", res.Result.Cn)

--- a/resource_sudo_cmdgroup.go
+++ b/resource_sudo_cmdgroup.go
@@ -79,7 +79,6 @@ func resourceFreeIPASudocmdgroupRead(ctx context.Context, d *schema.ResourceData
 	}
 
 	res, err := client.SudocmdgroupShow(&args, &optArgs)
-
 	if err != nil {
 		if strings.Contains(err.Error(), "NotFound") {
 			d.SetId("")

--- a/resource_sudo_cmdgroup_membership.go
+++ b/resource_sudo_cmdgroup_membership.go
@@ -89,7 +89,6 @@ func resourceFreeIPASudocmdgroupMembershipRead(ctx context.Context, d *schema.Re
 	}
 
 	res, err := client.SudocmdgroupShow(&args, &optArgs)
-
 	if err != nil {
 		if strings.Contains(err.Error(), "NotFound") {
 			d.SetId("")

--- a/resource_sudo_cmdgroup_membership.go
+++ b/resource_sudo_cmdgroup_membership.go
@@ -90,6 +90,16 @@ func resourceFreeIPASudocmdgroupMembershipRead(ctx context.Context, d *schema.Re
 
 	res, err := client.SudocmdgroupShow(&args, &optArgs)
 
+	if err != nil {
+		if strings.Contains(err.Error(), "NotFound") {
+			d.SetId("")
+			log.Printf("[DEBUG] Sudo command group not found")
+			return nil
+		} else {
+			return diag.Errorf("Error reading freeipa Sudo command group: %s", err)
+		}
+	}
+
 	switch typeId {
 	case "sc":
 		if res.Result.MemberSudocmd == nil || !slices.Contains(*res.Result.MemberSudocmd, cmdId) {
@@ -97,7 +107,7 @@ func resourceFreeIPASudocmdgroupMembershipRead(ctx context.Context, d *schema.Re
 			d.Set("name", "")
 			d.Set("sudocmd", "")
 			d.SetId("")
-			return diag.Errorf("Error configuring freeipa Sudo command group, sudocmd not assigned: %s", cmdId)
+			return nil
 		}
 	}
 

--- a/resource_sudo_rule.go
+++ b/resource_sudo_rule.go
@@ -139,7 +139,6 @@ func resourceFreeIPASudoRuleRead(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	res, err := client.SudoruleShow(&args, &optArgs)
-
 	if err != nil {
 		if strings.Contains(err.Error(), "NotFound") {
 			d.SetId("")

--- a/resource_sudo_rule.go
+++ b/resource_sudo_rule.go
@@ -141,7 +141,13 @@ func resourceFreeIPASudoRuleRead(ctx context.Context, d *schema.ResourceData, me
 	res, err := client.SudoruleShow(&args, &optArgs)
 
 	if err != nil {
-		return diag.Errorf("Error show freeipa sudo rule: %s", err)
+		if strings.Contains(err.Error(), "NotFound") {
+			d.SetId("")
+			log.Printf("[DEBUG] Sudo rule not found")
+			return nil
+		} else {
+			return diag.Errorf("Error reading freeipa sudo rule: %s", err)
+		}
 	}
 
 	log.Printf("[DEBUG] Read freeipa sudo rule %s", res.Result.Cn)

--- a/resource_sudo_rule_allowcmd_membership.go
+++ b/resource_sudo_rule_allowcmd_membership.go
@@ -110,7 +110,6 @@ func resourceFreeIPASudoRuleAllowCommandMembershipRead(ctx context.Context, d *s
 	}
 
 	res, err := client.SudoruleShow(&args, &optArgs)
-
 	if err != nil {
 		if strings.Contains(err.Error(), "NotFound") {
 			d.SetId("")

--- a/resource_sudo_rule_allowcmd_membership.go
+++ b/resource_sudo_rule_allowcmd_membership.go
@@ -111,6 +111,16 @@ func resourceFreeIPASudoRuleAllowCommandMembershipRead(ctx context.Context, d *s
 
 	res, err := client.SudoruleShow(&args, &optArgs)
 
+	if err != nil {
+		if strings.Contains(err.Error(), "NotFound") {
+			d.SetId("")
+			log.Printf("[DEBUG] Sudo rule not found")
+			return nil
+		} else {
+			return diag.Errorf("Error reading freeipa sudo rule: %s", err)
+		}
+	}
+
 	switch typeId {
 	case "srac":
 		if res.Result.MemberallowcmdSudocmd == nil || !slices.Contains(*res.Result.MemberallowcmdSudocmd, cmdId) {
@@ -119,7 +129,7 @@ func resourceFreeIPASudoRuleAllowCommandMembershipRead(ctx context.Context, d *s
 			d.Set("sudocmd", "")
 			d.Set("sudocmd_group", "")
 			d.SetId("")
-			return diag.Errorf("Error configuring freeipa Sudo rule allowed command, sudocmd not assigned: %s", cmdId)
+			return nil
 		}
 	case "sracg":
 		if res.Result.MemberallowcmdSudocmdgroup == nil || !slices.Contains(*res.Result.MemberallowcmdSudocmdgroup, cmdId) {
@@ -128,7 +138,7 @@ func resourceFreeIPASudoRuleAllowCommandMembershipRead(ctx context.Context, d *s
 			d.Set("sudocmd", "")
 			d.Set("sudocmd_group", "")
 			d.SetId("")
-			return diag.Errorf("Error configuring freeipa Sudo rule allowed command, sudocmd not assigned: %s", cmdId)
+			return nil
 		}
 	}
 

--- a/resource_sudo_rule_denycmd_membership.go
+++ b/resource_sudo_rule_denycmd_membership.go
@@ -110,7 +110,6 @@ func resourceFreeIPASudoRuleDenyCommandMembershipRead(ctx context.Context, d *sc
 	}
 
 	res, err := client.SudoruleShow(&args, &optArgs)
-
 	if err != nil {
 		if strings.Contains(err.Error(), "NotFound") {
 			d.SetId("")

--- a/resource_sudo_rule_denycmd_membership.go
+++ b/resource_sudo_rule_denycmd_membership.go
@@ -111,6 +111,16 @@ func resourceFreeIPASudoRuleDenyCommandMembershipRead(ctx context.Context, d *sc
 
 	res, err := client.SudoruleShow(&args, &optArgs)
 
+	if err != nil {
+		if strings.Contains(err.Error(), "NotFound") {
+			d.SetId("")
+			log.Printf("[DEBUG] Sudo rule not found")
+			return nil
+		} else {
+			return diag.Errorf("Error reading freeipa sudo rule: %s", err)
+		}
+	}
+
 	switch typeId {
 	case "srdc":
 		if res.Result.MemberdenycmdSudocmd == nil || !slices.Contains(*res.Result.MemberdenycmdSudocmd, cmdId) {
@@ -119,7 +129,7 @@ func resourceFreeIPASudoRuleDenyCommandMembershipRead(ctx context.Context, d *sc
 			d.Set("sudocmd", "")
 			d.Set("sudocmd_group", "")
 			d.SetId("")
-			return diag.Errorf("Error configuring freeipa Sudo rule denied command, sudocmd not assigned: %s", cmdId)
+			return nil
 		}
 	case "srdcg":
 		if res.Result.MemberdenycmdSudocmdgroup == nil || !slices.Contains(*res.Result.MemberdenycmdSudocmdgroup, cmdId) {
@@ -128,7 +138,7 @@ func resourceFreeIPASudoRuleDenyCommandMembershipRead(ctx context.Context, d *sc
 			d.Set("sudocmd", "")
 			d.Set("sudocmd_group", "")
 			d.SetId("")
-			return diag.Errorf("Error configuring freeipa Sudo rule denied command, sudocmd not assigned: %s", cmdId)
+			return nil
 		}
 	}
 

--- a/resource_sudo_rule_host_membership.go
+++ b/resource_sudo_rule_host_membership.go
@@ -128,6 +128,16 @@ func resourceFreeIPASudoRuleHostMembershipRead(ctx context.Context, d *schema.Re
 
 	res, err := client.SudoruleShow(&args, &optArgs)
 
+	if err != nil {
+		if strings.Contains(err.Error(), "NotFound") {
+			d.SetId("")
+			log.Printf("[DEBUG] Sudo rule not found")
+			return nil
+		} else {
+			return diag.Errorf("Error reading freeipa sudo rule: %s", err)
+		}
+	}
+
 	switch typeId {
 	case "srh":
 		if res.Result.MemberhostHost == nil || !slices.Contains(*res.Result.MemberhostHost, host_id) {
@@ -136,7 +146,7 @@ func resourceFreeIPASudoRuleHostMembershipRead(ctx context.Context, d *schema.Re
 			d.Set("host", "")
 			d.Set("hostgroup", "")
 			d.SetId("")
-			return diag.Errorf("Error configuring freeipa Sudo rule host, host not assigned: %s", host_id)
+			return nil
 		}
 	case "srhg":
 		if res.Result.MemberhostHostgroup == nil || !slices.Contains(*res.Result.MemberhostHostgroup, host_id) {
@@ -145,7 +155,7 @@ func resourceFreeIPASudoRuleHostMembershipRead(ctx context.Context, d *schema.Re
 			d.Set("host", "")
 			d.Set("hostgroup", "")
 			d.SetId("")
-			return diag.Errorf("Error configuring freeipa Sudo rule host, hostgroup not assigned: %s", host_id)
+			return nil
 		}
 		// Hostmask not implemented yet. Maybe one day but I don't see the need.
 		// case "srhm":

--- a/resource_sudo_rule_host_membership.go
+++ b/resource_sudo_rule_host_membership.go
@@ -127,7 +127,6 @@ func resourceFreeIPASudoRuleHostMembershipRead(ctx context.Context, d *schema.Re
 	}
 
 	res, err := client.SudoruleShow(&args, &optArgs)
-
 	if err != nil {
 		if strings.Contains(err.Error(), "NotFound") {
 			d.SetId("")

--- a/resource_sudo_rule_option.go
+++ b/resource_sudo_rule_option.go
@@ -87,6 +87,16 @@ func resourceFreeIPASudoRuleOptionRead(ctx context.Context, d *schema.ResourceDa
 
 	res, err := client.SudoruleShow(&args, &optArgs)
 
+	if err != nil {
+		if strings.Contains(err.Error(), "NotFound") {
+			d.SetId("")
+			log.Printf("[DEBUG] Sudo rule not found")
+			return nil
+		} else {
+			return diag.Errorf("Error reading freeipa sudo rule: %s", err)
+		}
+	}
+
 	switch typeId {
 	case "sro":
 		if res.Result.Ipasudoopt == nil || !slices.Contains(*res.Result.Ipasudoopt, opt_id) {
@@ -94,12 +104,8 @@ func resourceFreeIPASudoRuleOptionRead(ctx context.Context, d *schema.ResourceDa
 			d.Set("name", "")
 			d.Set("option", "")
 			d.SetId("")
-			return diag.Errorf("Error configuring freeipa Sudo rule option, option not assigned: %s", opt_id)
+			return nil
 		}
-	}
-
-	if err != nil {
-		return diag.Errorf("Error show freeipa sudo rule option: %s", err)
 	}
 
 	log.Printf("[DEBUG] Read freeipa sudo rule option %s", res.Result.Cn)

--- a/resource_sudo_rule_option.go
+++ b/resource_sudo_rule_option.go
@@ -86,7 +86,6 @@ func resourceFreeIPASudoRuleOptionRead(ctx context.Context, d *schema.ResourceDa
 	}
 
 	res, err := client.SudoruleShow(&args, &optArgs)
-
 	if err != nil {
 		if strings.Contains(err.Error(), "NotFound") {
 			d.SetId("")

--- a/resource_sudo_rule_runasgroup_membership.go
+++ b/resource_sudo_rule_runasgroup_membership.go
@@ -96,6 +96,16 @@ func resourceFreeIPASudoRuleRunAsGroupMembershipRead(ctx context.Context, d *sch
 
 	res, err := client.SudoruleShow(&args, &optArgs)
 
+	if err != nil {
+		if strings.Contains(err.Error(), "NotFound") {
+			d.SetId("")
+			log.Printf("[DEBUG] Sudo rule not found")
+			return nil
+		} else {
+			return diag.Errorf("Error reading freeipa sudo rule: %s", err)
+		}
+	}
+
 	switch typeId {
 	case "srraug":
 		if (res.Result.IpasudorunasgroupGroup == nil || !slices.Contains(*res.Result.IpasudorunasgroupGroup, group_id)) && (res.Result.Ipasudorunasextgroup == nil || !slices.Contains(*res.Result.Ipasudorunasextgroup, group_id)) {
@@ -104,7 +114,7 @@ func resourceFreeIPASudoRuleRunAsGroupMembershipRead(ctx context.Context, d *sch
 			d.Set("runasgroup", "")
 			d.Set("runasgroup", "")
 			d.SetId("")
-			return diag.Errorf("Error configuring freeipa Sudo rule runasgroup, runasgroup not assigned: %s", group_id)
+			return nil
 		}
 	}
 

--- a/resource_sudo_rule_runasgroup_membership.go
+++ b/resource_sudo_rule_runasgroup_membership.go
@@ -95,7 +95,6 @@ func resourceFreeIPASudoRuleRunAsGroupMembershipRead(ctx context.Context, d *sch
 	}
 
 	res, err := client.SudoruleShow(&args, &optArgs)
-
 	if err != nil {
 		if strings.Contains(err.Error(), "NotFound") {
 			d.SetId("")

--- a/resource_sudo_rule_runasuser_membership.go
+++ b/resource_sudo_rule_runasuser_membership.go
@@ -95,7 +95,6 @@ func resourceFreeIPASudoRuleRunAsUserMembershipRead(ctx context.Context, d *sche
 	}
 
 	res, err := client.SudoruleShow(&args, &optArgs)
-
 	if err != nil {
 		if strings.Contains(err.Error(), "NotFound") {
 			d.SetId("")

--- a/resource_sudo_rule_runasuser_membership.go
+++ b/resource_sudo_rule_runasuser_membership.go
@@ -96,6 +96,16 @@ func resourceFreeIPASudoRuleRunAsUserMembershipRead(ctx context.Context, d *sche
 
 	res, err := client.SudoruleShow(&args, &optArgs)
 
+	if err != nil {
+		if strings.Contains(err.Error(), "NotFound") {
+			d.SetId("")
+			log.Printf("[DEBUG] Sudo rule not found")
+			return nil
+		} else {
+			return diag.Errorf("Error reading freeipa sudo rule: %s", err)
+		}
+	}
+
 	switch typeId {
 	case "srrau":
 		if (res.Result.IpasudorunasUser == nil || !slices.Contains(*res.Result.IpasudorunasUser, user_id)) && (res.Result.Ipasudorunasextuser == nil || !slices.Contains(*res.Result.Ipasudorunasextuser, user_id)) {
@@ -104,7 +114,7 @@ func resourceFreeIPASudoRuleRunAsUserMembershipRead(ctx context.Context, d *sche
 			d.Set("runasuser", "")
 			d.Set("runasgroup", "")
 			d.SetId("")
-			return diag.Errorf("Error configuring freeipa Sudo rule runasuser, runasuser not assigned: %s", user_id)
+			return nil
 		}
 	}
 

--- a/resource_sudo_rule_user_membership.go
+++ b/resource_sudo_rule_user_membership.go
@@ -110,6 +110,15 @@ func resourceFreeIPASudoRuleUserMembershipRead(ctx context.Context, d *schema.Re
 	}
 
 	res, err := client.SudoruleShow(&args, &optArgs)
+	if err != nil {
+		if strings.Contains(err.Error(), "NotFound") {
+			d.SetId("")
+			log.Printf("[DEBUG] Sudo rule not found")
+			return nil
+		} else {
+			return diag.Errorf("Error reading freeipa sudo rule: %s", err)
+		}
+	}
 
 	switch typeId {
 	case "sru":
@@ -119,16 +128,16 @@ func resourceFreeIPASudoRuleUserMembershipRead(ctx context.Context, d *schema.Re
 			d.Set("user", "")
 			d.Set("group", "")
 			d.SetId("")
-			return diag.Errorf("Error configuring freeipa Sudo rule user, user not assigned: %s", user_id)
+			return nil
 		}
 	case "srug":
 		if res.Result.MemberuserGroup == nil || !slices.Contains(*res.Result.MemberuserGroup, user_id) {
-			log.Printf("[DEBUG] Warning! Sudo rule user membership does not exist")
+			log.Printf("[DEBUG] Warning! Sudo rule group membership does not exist")
 			d.Set("name", "")
 			d.Set("user", "")
 			d.Set("group", "")
 			d.SetId("")
-			return diag.Errorf("Error configuring freeipa Sudo rule user, group not assigned: %s", user_id)
+			return nil
 		}
 	}
 

--- a/resource_user.go
+++ b/resource_user.go
@@ -350,10 +350,18 @@ func resourceFreeIPADNSUserRead(ctx context.Context, d *schema.ResourceData, met
 		v := _v.(string)
 		optArgs.UID = &v
 	}
+
+	log.Printf("[DEBUG] Read freeipa user %s", d.Id())
 	res, err := client.UserShow(&ipa.UserShowArgs{}, &optArgs)
 
 	if err != nil {
-		return diag.Errorf("Error show freeipa user: %s", err)
+		if strings.Contains(err.Error(), "NotFound") {
+			d.SetId("")
+			log.Printf("[DEBUG] User not found")
+			return nil
+		} else {
+			return diag.Errorf("Error reading freeipa user: %s", err)
+		}
 	}
 
 	log.Printf("[DEBUG] Read freeipa user %s", res.Result.UID)

--- a/resource_user.go
+++ b/resource_user.go
@@ -353,7 +353,6 @@ func resourceFreeIPADNSUserRead(ctx context.Context, d *schema.ResourceData, met
 
 	log.Printf("[DEBUG] Read freeipa user %s", d.Id())
 	res, err := client.UserShow(&ipa.UserShowArgs{}, &optArgs)
-
 	if err != nil {
 		if strings.Contains(err.Error(), "NotFound") {
 			d.SetId("")

--- a/resource_user_group_membership.go
+++ b/resource_user_group_membership.go
@@ -121,6 +121,7 @@ func resourceFreeIPAUserGroupMembershipRead(ctx context.Context, d *schema.Resou
 		log.Printf("[DEBUG] Warning! Group or User membership not exist")
 		d.Set("user", "")
 		d.Set("group", "")
+		d.SetId("")
 	}
 
 	return nil


### PR DESCRIPTION
When resources that were create with the provider are removed manually in freeipa, the next terraform plan/apply should rebuild them.