### PR TITLE
HostAdd skip DNS check

### DIFF
--- a/resource_host.go
+++ b/resource_host.go
@@ -123,6 +123,12 @@ func resourceFreeIPAHost() *schema.Resource {
 				Optional:    true,
 				Description: "The service is allowed to authenticate on behalf of a client",
 			},
+			"force": {
+				Type:        schema.TypeBool,
+				Required:    false,
+				Optional:    true,
+				Description: "Skip host's DNS check (A/AAAA) before adding it",
+			},
 		},
 	}
 }
@@ -204,6 +210,11 @@ func resourceFreeIPADNSHostCreate(ctx context.Context, d *schema.ResourceData, m
 	if _v, ok := d.GetOkExists("trusted_to_auth_as_delegation"); ok {
 		v := _v.(bool)
 		optArgs.Ipakrboktoauthasdelegate = &v
+	}
+
+	if _v, ok := d.GetOkExists("force"); ok {
+		v := _v.(bool)
+		optArgs.Force = &v
 	}
 	_, err = client.HostAdd(&args, &optArgs)
 	if err != nil {


### PR DESCRIPTION
Hello there :wave: 

Here is a little PR in order to allow the host's DNS check to be skipped when adding a host.

To explain a bit more about the why:

* We create our vm via terraform and we want to add it to freeipa before the vm resource is created.
* On boot, the vm will enroll itself via cloud_init

Thanks to its previous addition via terraform, we can cleanup freeipa on vm resource destruction :smile: 