### PR TITLE
Add support for custom SSL CA certificate files

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,7 @@ provider "freeipa" {
 
 ### Optional
 
+- `ca_certificate` (String) Path to the server's SSL CA certificate
 - `host` (String) The FreeIPA host
 - `insecure` (Boolean) Whether to verify the server's SSL certificate
 - `password` (String) Password to use for connection
@@ -39,4 +40,4 @@ provider "freeipa" {
 ## Environment Variables
 
 Configuration can be provided by setting the `FREEIPA_HOST`, `FREEIPA_USERNAME`,
-and `FREEIPA_PASSWORD` environment variables.
+`FREEIPA_PASSWORD`, and `FREEIPA_CA_CERT` environment variables.

--- a/freeipa/config.go
+++ b/freeipa/config.go
@@ -2,8 +2,10 @@ package freeipa
 
 import (
 	"crypto/tls"
+	"crypto/x509"
 	"log"
 	"net/http"
+	"os"
 
 	ipa "github.com/RomanButsiy/go-freeipa/freeipa"
 )
@@ -14,13 +16,25 @@ type Config struct {
 	Username           string
 	Password           string
 	InsecureSkipVerify bool
+	CaCertificate      string
 }
 
 // Client creates a FreeIPA client scoped to the global API
 func (c *Config) Client() (*ipa.Client, error) {
+	caCertPool := x509.NewCertPool()
+
+	if c.CaCertificate != "" {
+		caCert, err := os.ReadFile(c.CaCertificate)
+		if err != nil {
+			return nil, err
+		}
+		caCertPool.AppendCertsFromPEM(caCert)
+	}
+
 	tspt := &http.Transport{
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: c.InsecureSkipVerify,
+			RootCAs:            caCertPool,
 		},
 	}
 

--- a/freeipa/provider.go
+++ b/freeipa/provider.go
@@ -32,6 +32,12 @@ func Provider() *schema.Provider {
 				Default:     false,
 				Description: descriptions["insecure"],
 			},
+			"ca_certificate": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("FREEIPA_CA_CERT", ""),
+				Description: descriptions["ca_certificate"],
+			},
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -80,6 +86,8 @@ func init() {
 		"password": "Password to use for connection",
 
 		"insecure": "Whether to verify the server's SSL certificate",
+
+		"ca_certificate": "Path to the server's SSL CA certificate",
 	}
 }
 
@@ -89,5 +97,6 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		Username:           d.Get("username").(string),
 		Password:           d.Get("password").(string),
 		InsecureSkipVerify: d.Get("insecure").(bool),
+		CaCertificate:      d.Get("ca_certificate").(string),
 	}, nil
 }


### PR DESCRIPTION
Many FreeIPA deployments use a self-signed CA certificate for their web server.  This makes it possible to avoid using insecure=True in such cases.