### PR TITLE
feat: add external group members to external groups

### DIFF
--- a/docs/resources/user_group_membership.md
+++ b/docs/resources/user_group_membership.md
@@ -36,6 +36,7 @@ resource freeipa_user_group_membership "test-1" {
 
 - `group` (String) Group to add
 - `user` (String) User to add
+- `external_member` (String) External member to add. Only for external groups. Requires a valid AD Trust configuration.
 
 ### Read-Only
 

--- a/examples/resources/freeipa_user_group_membership/resource.tf
+++ b/examples/resources/freeipa_user_group_membership/resource.tf
@@ -3,7 +3,17 @@ resource freeipa_user_group_membership "test-0" {
   user = "roman"
 }
 
+resource freeipa_user_group_membership "test-external-0" {
+  name            = "test-group-2"
+  external_member = "roman@domain"
+}
+
 resource freeipa_user_group_membership "test-1" {
   name = "test-group-2"
   group = "test-group"
+}
+
+resource freeipa_user_group_membership "test-external-1" {
+  name = "test-group-2"
+  external_member = "test-group@domain"
 }

--- a/examples/resources/freeipa_user_group_membership/resource.tf
+++ b/examples/resources/freeipa_user_group_membership/resource.tf
@@ -3,17 +3,7 @@ resource freeipa_user_group_membership "test-0" {
   user = "roman"
 }
 
-resource freeipa_user_group_membership "test-external-0" {
-  name            = "test-group-2"
-  external_member = "roman@domain"
-}
-
 resource freeipa_user_group_membership "test-1" {
   name = "test-group-2"
   group = "test-group"
-}
-
-resource freeipa_user_group_membership "test-external-1" {
-  name = "test-group-2"
-  external_member = "test-group@domain"
 }

--- a/freeipa/resource_user_group_membership.go
+++ b/freeipa/resource_user_group_membership.go
@@ -9,6 +9,7 @@ import (
 	ipa "github.com/RomanButsiy/go-freeipa/freeipa"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"golang.org/x/exp/slices"
 )
 
 func resourceFreeIPAUserGroupMembership() *schema.Resource {
@@ -31,15 +32,22 @@ func resourceFreeIPAUserGroupMembership() *schema.Resource {
 				Type:          schema.TypeString,
 				Optional:      true,
 				ForceNew:      true,
-				ConflictsWith: []string{"group"},
+				ConflictsWith: []string{"group","external_member"},
 				Description:   "User to add",
 			},
 			"group": {
 				Type:          schema.TypeString,
 				Optional:      true,
 				ForceNew:      true,
-				ConflictsWith: []string{"user"},
+				ConflictsWith: []string{"user","external_member"},
 				Description:   "Group to add",
+			},
+			"external_member": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"user","group"},
+				Description:   "External member to add. name must refer to an external group. (Requires a valid AD Trust configuration).",
 			},
 		},
 	}
@@ -71,9 +79,21 @@ func resourceFreeIPAUserGroupMembershipCreate(ctx context.Context, d *schema.Res
 		user_id = "g"
 	}
 
-	_, err = client.GroupAddMember(&args, &optArgs)
+	if _v, ok := d.GetOkExists("external_member"); ok {
+		v := []string{_v.(string)}
+		optArgs.Ipaexternalmember = &v
+		user_id = "e"
+	}
+
+	_v, err := client.GroupAddMember(&args, &optArgs)
 	if err != nil {
 		return diag.Errorf("Error creating freeipa the user group membership: %s", err)
+	}
+	log.Printf("[DEBUG] Group add member response for group %s is %v", args.Cn, _v.Result)
+	log.Printf("[DEBUG] Group add member failure for group %s is %v", args.Cn, _v.Failed)
+	log.Printf("[DEBUG] Group add member number added for group %s is %d", args.Cn, _v.Completed)
+	if _v.Completed == 0 {
+		return diag.Errorf("Error creating freeipa the user group membership: %v", _v.Failed)
 	}
 
 	switch user_id {
@@ -82,6 +102,9 @@ func resourceFreeIPAUserGroupMembershipCreate(ctx context.Context, d *schema.Res
 		d.SetId(id)
 	case "u":
 		id := fmt.Sprintf("%s/u/%s", d.Get("name").(string), d.Get("user").(string))
+		d.SetId(id)
+	case "e":
+		id := fmt.Sprintf("%s/e/%s", d.Get("name").(string), d.Get("external_member").(string))
 		d.SetId(id)
 	}
 
@@ -102,7 +125,7 @@ func resourceFreeIPAUserGroupMembershipRead(ctx context.Context, d *schema.Resou
 		return diag.Errorf("Error creating freeipa identity client: %s", err)
 	}
 
-	optArgs := ipa.GroupFindOptionalArgs{
+	/*optArgs := ipa.GroupFindOptionalArgs{
 		Cn: &name,
 	}
 
@@ -111,6 +134,9 @@ func resourceFreeIPAUserGroupMembershipRead(ctx context.Context, d *schema.Resou
 		v := []string{userId}
 		optArgs.Group = &v
 	case "u":
+		v := []string{userId}
+		optArgs.User = &v
+	case "e":
 		v := []string{userId}
 		optArgs.User = &v
 	}
@@ -124,8 +150,55 @@ func resourceFreeIPAUserGroupMembershipRead(ctx context.Context, d *schema.Resou
 		log.Printf("[DEBUG] Warning! Group or User membership not exist")
 		d.Set("user", "")
 		d.Set("group", "")
+		d.Set("external_member", "")
 		d.SetId("")
+	}*/
+
+	reqArgs := ipa.GroupShowArgs{
+		Cn: name,
 	}
+	z := new(bool)
+	*z = true
+	optArgs := ipa.GroupShowOptionalArgs{
+		All: z,
+	}
+
+	res, err := client.GroupShow(&reqArgs, &optArgs)
+	if err != nil {
+		return diag.Errorf("Error find freeipa the user group membership: %s", err)
+	}
+
+	
+	log.Printf("[DEBUG] group show %s is %v", name, res.Result.String())
+
+	switch typeId {
+	case "g":
+		v := []string{userId}
+		groups := *res.Result.MemberGroup
+		log.Printf("[DEBUG] Group list in group %s is %v", name, groups)
+		if slices.Contains(groups, v[0]) {
+			return nil
+		}
+	case "u":
+		v := []string{userId}
+		users := *res.Result.MemberUser
+		log.Printf("[DEBUG] User list in group %s is %v", name, users)
+		if slices.Contains(users, v[0]) {
+			return nil
+		}
+	case "e":
+		v := []string{userId}
+		extmembers := *res.Result.Ipaexternalmember
+		log.Printf("[DEBUG] External member list in group %s is %v", name, extmembers)
+		if slices.Contains(extmembers, v[0]) {
+			return nil
+		}
+	}
+	log.Printf("[DEBUG] Warning! Group or User membership not exist")
+	d.Set("user", "")
+	d.Set("group", "")
+	d.Set("external_member", "")
+	d.SetId("")
 
 	return nil
 }
@@ -157,6 +230,9 @@ func resourceFreeIPAUserGroupMembershipDelete(ctx context.Context, d *schema.Res
 	case "u":
 		v := []string{userId}
 		optArgs.User = &v
+	case "e":
+		v := []string{userId}
+		optArgs.Ipaexternalmember = &v
 	}
 
 	_, err = client.GroupRemoveMember(&args, &optArgs)

--- a/freeipa/resource_user_group_membership.go
+++ b/freeipa/resource_user_group_membership.go
@@ -32,21 +32,21 @@ func resourceFreeIPAUserGroupMembership() *schema.Resource {
 				Type:          schema.TypeString,
 				Optional:      true,
 				ForceNew:      true,
-				ConflictsWith: []string{"group","external_member"},
+				ConflictsWith: []string{"group", "external_member"},
 				Description:   "User to add",
 			},
 			"group": {
 				Type:          schema.TypeString,
 				Optional:      true,
 				ForceNew:      true,
-				ConflictsWith: []string{"user","external_member"},
+				ConflictsWith: []string{"user", "external_member"},
 				Description:   "Group to add",
 			},
 			"external_member": {
 				Type:          schema.TypeString,
 				Optional:      true,
 				ForceNew:      true,
-				ConflictsWith: []string{"user","group"},
+				ConflictsWith: []string{"user", "group"},
 				Description:   "External member to add. name must refer to an external group. (Requires a valid AD Trust configuration).",
 			},
 		},
@@ -168,7 +168,6 @@ func resourceFreeIPAUserGroupMembershipRead(ctx context.Context, d *schema.Resou
 		return diag.Errorf("Error find freeipa the user group membership: %s", err)
 	}
 
-	
 	log.Printf("[DEBUG] group show %s is %v", name, res.Result.String())
 
 	switch typeId {

--- a/freeipa/resource_user_group_membership.go
+++ b/freeipa/resource_user_group_membership.go
@@ -125,35 +125,6 @@ func resourceFreeIPAUserGroupMembershipRead(ctx context.Context, d *schema.Resou
 		return diag.Errorf("Error creating freeipa identity client: %s", err)
 	}
 
-	/*optArgs := ipa.GroupFindOptionalArgs{
-		Cn: &name,
-	}
-
-	switch typeId {
-	case "g":
-		v := []string{userId}
-		optArgs.Group = &v
-	case "u":
-		v := []string{userId}
-		optArgs.User = &v
-	case "e":
-		v := []string{userId}
-		optArgs.User = &v
-	}
-
-	res, err := client.GroupFind("", &ipa.GroupFindArgs{}, &optArgs)
-	if err != nil {
-		return diag.Errorf("Error find freeipa the user group membership: %s", err)
-	}
-
-	if strings.Contains(*res.Summary, "0 groups matched") {
-		log.Printf("[DEBUG] Warning! Group or User membership not exist")
-		d.Set("user", "")
-		d.Set("group", "")
-		d.Set("external_member", "")
-		d.SetId("")
-	}*/
-
 	reqArgs := ipa.GroupShowArgs{
 		Cn: name,
 	}

--- a/freeipa/resource_user_group_membership_test.go
+++ b/freeipa/resource_user_group_membership_test.go
@@ -20,6 +20,16 @@ func TestAccFreeIPADNSUserGroupMembership(t *testing.T) {
 	testDatasetGroup2 := map[string]string{
 		"name": "testgroup-2",
 	}
+	testDatasetGroup3 := map[string]string{
+		"name": "testgroup-3",
+	}
+
+	/*testDatasetExtGroup := map[string]string{
+		"name": "testgroup-ext",
+	}
+	testDatasetExtGroup2 := map[string]string{
+		"name": "testgroup2-ext",
+	}*/
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -28,17 +38,32 @@ func TestAccFreeIPADNSUserGroupMembership(t *testing.T) {
 			{
 				Config: testAccFreeIPADNSUserGroupMembershipResource_user(testDatasetUser, testDatasetGroup),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("freeipa_user_group_membership.groupemembership", "name", testDatasetGroup["name"]),
-					resource.TestCheckResourceAttr("freeipa_user_group_membership.groupemembership", "user", testDatasetUser["login"]),
+					resource.TestCheckResourceAttr("freeipa_user_group_membership.groupmembership", "name", testDatasetGroup["name"]),
+					resource.TestCheckResourceAttr("freeipa_user_group_membership.groupmembership", "user", testDatasetUser["login"]),
 				),
 			},
 			{
-				Config: testAccFreeIPADNSUserGroupMembershipResource_group(testDatasetGroup, testDatasetGroup2),
+				Config: testAccFreeIPADNSUserGroupMembershipResource_group(testDatasetGroup3, testDatasetGroup2),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("freeipa_user_group_membership.groupemembership", "name", testDatasetGroup["name"]),
-					resource.TestCheckResourceAttr("freeipa_user_group_membership.groupemembership", "group", testDatasetGroup2["name"]),
+					resource.TestCheckResourceAttr("freeipa_user_group_membership.groupmembership2", "name", testDatasetGroup3["name"]),
+					resource.TestCheckResourceAttr("freeipa_user_group_membership.groupmembership2", "group", testDatasetGroup2["name"]),
 				),
 			},
+			// External users need a valid trust setup to work. Not possible for acceptance test
+			/*{
+				Config: testAccFreeIPADNSUserGroupMembershipResource_externaluser(testDatasetExtGroup),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("freeipa_user_group_membership.groupmembership3", "name", testDatasetExtGroup["name"]),
+					resource.TestCheckResourceAttr("freeipa_user_group_membership.groupmembership3", "external_member", "user@domain"),
+				),
+			},
+			{
+				Config: testAccFreeIPADNSUserGroupMembershipResource_externalgroup(testDatasetExtGroup2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("freeipa_user_group_membership.groupmembership4", "name", testDatasetExtGroup2["name"]),
+					resource.TestCheckResourceAttr("freeipa_user_group_membership.groupmembership4", "external_member", "usergroup@domain"),
+				),
+			},*/
 		},
 	})
 }
@@ -64,7 +89,7 @@ func testAccFreeIPADNSUserGroupMembershipResource_user(dataset_user map[string]s
 	resource "freeipa_group" "group" {
 		name       = "%s"
 	}
-	resource freeipa_user_group_membership "groupemembership" {
+	resource freeipa_user_group_membership "groupmembership" {
 	   name = resource.freeipa_group.group.id
 	   user = resource.freeipa_user.user.id
 	}
@@ -83,16 +108,64 @@ func testAccFreeIPADNSUserGroupMembershipResource_group(dataset_group map[string
 		insecure = true
 	  }
 	
-	resource "freeipa_group" "group" {
+	resource "freeipa_group" "group2" {
 		name       = "%s"
 	}
 	resource "freeipa_group" "subgroup" {
 		name       = "%s"
 	}
 
-	resource freeipa_user_group_membership "groupemembership" {
-	   name = resource.freeipa_group.group.id
+	resource freeipa_user_group_membership "groupmembership2" {
+	   name = resource.freeipa_group.group2.id
 	   group = resource.freeipa_group.subgroup.id
 	}
 	`, provider_host, provider_user, provider_pass, dataset_group["name"], dataset_group2["name"])
 }
+
+/*func testAccFreeIPADNSUserGroupMembershipResource_externaluser(dataset_group map[string]string) string {
+	provider_host := os.Getenv("FREEIPA_HOST")
+	provider_user := os.Getenv("FREEIPA_USERNAME")
+	provider_pass := os.Getenv("FREEIPA_PASSWORD")
+	return fmt.Sprintf(`
+	provider "freeipa" {
+		host     = "%s"
+		username = "%s"
+		password = "%s"
+		insecure = true
+	  }
+
+	resource "freeipa_group" "group3" {
+		name       = "%s"
+		external = true
+	}
+	resource freeipa_user_group_membership "groupmembership3" {
+	   name     = resource.freeipa_group.group3.id
+	   external_member = "user@domain"
+	}
+	`, provider_host, provider_user, provider_pass, dataset_group["name"])
+}
+
+func testAccFreeIPADNSUserGroupMembershipResource_externalgroup(dataset_group map[string]string) string {
+	provider_host := os.Getenv("FREEIPA_HOST")
+	provider_user := os.Getenv("FREEIPA_USERNAME")
+	provider_pass := os.Getenv("FREEIPA_PASSWORD")
+	return fmt.Sprintf(`
+	provider "freeipa" {
+		host     = "%s"
+		username = "%s"
+		password = "%s"
+		insecure = true
+	  }
+	
+	resource "freeipa_group" "group4" {
+		name       = "%s"
+		external   = true
+	}
+
+	resource freeipa_user_group_membership "groupmembership4" {
+	   name     = resource.freeipa_group.group4.id
+	   external_member = "usergroup@domain"
+	}
+	}
+	`, provider_host, provider_user, provider_pass, dataset_group["name"])
+}*/

--- a/freeipa/resource_user_group_membership_test.go
+++ b/freeipa/resource_user_group_membership_test.go
@@ -156,7 +156,7 @@ func testAccFreeIPADNSUserGroupMembershipResource_externalgroup(dataset_group ma
 		password = "%s"
 		insecure = true
 	  }
-	
+
 	resource "freeipa_group" "group4" {
 		name       = "%s"
 		external   = true

--- a/freeipa/resource_user_group_membership_test.go
+++ b/freeipa/resource_user_group_membership_test.go
@@ -24,13 +24,6 @@ func TestAccFreeIPADNSUserGroupMembership(t *testing.T) {
 		"name": "testgroup-3",
 	}
 
-	/*testDatasetExtGroup := map[string]string{
-		"name": "testgroup-ext",
-	}
-	testDatasetExtGroup2 := map[string]string{
-		"name": "testgroup2-ext",
-	}*/
-
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
@@ -49,21 +42,6 @@ func TestAccFreeIPADNSUserGroupMembership(t *testing.T) {
 					resource.TestCheckResourceAttr("freeipa_user_group_membership.groupmembership2", "group", testDatasetGroup2["name"]),
 				),
 			},
-			// External users need a valid trust setup to work. Not possible for acceptance test
-			/*{
-				Config: testAccFreeIPADNSUserGroupMembershipResource_externaluser(testDatasetExtGroup),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("freeipa_user_group_membership.groupmembership3", "name", testDatasetExtGroup["name"]),
-					resource.TestCheckResourceAttr("freeipa_user_group_membership.groupmembership3", "external_member", "user@domain"),
-				),
-			},
-			{
-				Config: testAccFreeIPADNSUserGroupMembershipResource_externalgroup(testDatasetExtGroup2),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("freeipa_user_group_membership.groupmembership4", "name", testDatasetExtGroup2["name"]),
-					resource.TestCheckResourceAttr("freeipa_user_group_membership.groupmembership4", "external_member", "usergroup@domain"),
-				),
-			},*/
 		},
 	})
 }
@@ -121,51 +99,3 @@ func testAccFreeIPADNSUserGroupMembershipResource_group(dataset_group map[string
 	}
 	`, provider_host, provider_user, provider_pass, dataset_group["name"], dataset_group2["name"])
 }
-
-/*func testAccFreeIPADNSUserGroupMembershipResource_externaluser(dataset_group map[string]string) string {
-	provider_host := os.Getenv("FREEIPA_HOST")
-	provider_user := os.Getenv("FREEIPA_USERNAME")
-	provider_pass := os.Getenv("FREEIPA_PASSWORD")
-	return fmt.Sprintf(`
-	provider "freeipa" {
-		host     = "%s"
-		username = "%s"
-		password = "%s"
-		insecure = true
-	  }
-
-	resource "freeipa_group" "group3" {
-		name       = "%s"
-		external = true
-	}
-	resource freeipa_user_group_membership "groupmembership3" {
-	   name     = resource.freeipa_group.group3.id
-	   external_member = "user@domain"
-	}
-	`, provider_host, provider_user, provider_pass, dataset_group["name"])
-}
-
-func testAccFreeIPADNSUserGroupMembershipResource_externalgroup(dataset_group map[string]string) string {
-	provider_host := os.Getenv("FREEIPA_HOST")
-	provider_user := os.Getenv("FREEIPA_USERNAME")
-	provider_pass := os.Getenv("FREEIPA_PASSWORD")
-	return fmt.Sprintf(`
-	provider "freeipa" {
-		host     = "%s"
-		username = "%s"
-		password = "%s"
-		insecure = true
-	  }
-
-	resource "freeipa_group" "group4" {
-		name       = "%s"
-		external   = true
-	}
-
-	resource freeipa_user_group_membership "groupmembership4" {
-	   name     = resource.freeipa_group.group4.id
-	   external_member = "usergroup@domain"
-	}
-	}
-	`, provider_host, provider_user, provider_pass, dataset_group["name"])
-}*/

--- a/go.mod
+++ b/go.mod
@@ -9,10 +9,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.17.0
 )
 
-require (
-	github.com/hashicorp/terraform-plugin-docs v0.10.1
-	golang.org/x/exp v0.0.0-20230203172020-98cc5a0785f9
-)
+require golang.org/x/exp v0.0.0-20230203172020-98cc5a0785f9
 
 require (
 	github.com/Masterminds/goutils v1.1.1 // indirect


### PR DESCRIPTION
Unfortunately I don't have an AD to create a trust with, so I can't test it. For the same reason, it is not included in the acceptance tests.
I made sure that other group membership features are still working correctly.
Can someone test this PR? 