### PR TITLE
improve check on creation in case of silent failure

### DIFF
--- a/freeipa/resource_automemberadd_condition.go
+++ b/freeipa/resource_automemberadd_condition.go
@@ -93,9 +93,12 @@ func resourceFreeIPAAutomemberaddConditionCreate(ctx context.Context, d *schema.
 		}
 		optArgs.Automemberexclusiveregex = &v
 	}
-	_, err = client.AutomemberAddCondition(&args, &optArgs)
+	_v, err := client.AutomemberAddCondition(&args, &optArgs)
 	if err != nil {
 		return diag.Errorf("Error creating freeipa automember condition: %s", err)
+	}
+	if _v.Completed == 0 {
+		return diag.Errorf("Error creating freeipa automember condition: %v", _v.Failed)
 	}
 
 	d.SetId(d.Get("name").(string))

--- a/freeipa/resource_hbac_policy_host_membership.go
+++ b/freeipa/resource_hbac_policy_host_membership.go
@@ -72,10 +72,14 @@ func resourceFreeIPADNSHBACPolicyHostMembershipCreate(ctx context.Context, d *sc
 		hostmember_id = "hg"
 	}
 
-	_, err = client.HbacruleAddHost(&args, &optArgs)
+	_v, err := client.HbacruleAddHost(&args, &optArgs)
 	if err != nil {
 		return diag.Errorf("Error creating freeipa the HBAC policy host membership: %s", err)
 	}
+	if _v.Completed == 0 {
+		return diag.Errorf("Error creating freeipa the HBAC policy host membership: %v", _v.Failed)
+	}
+
 	switch hostmember_id {
 	case "hg":
 		id := fmt.Sprintf("%s/hg/%s", d.Get("name").(string), d.Get("hostgroup").(string))

--- a/freeipa/resource_hbac_policy_service_membership.go
+++ b/freeipa/resource_hbac_policy_service_membership.go
@@ -72,10 +72,14 @@ func resourceFreeIPADNSHBACPolicyServiceMembershipCreate(ctx context.Context, d 
 		svcmember_id = "sg"
 	}
 
-	_, err = client.HbacruleAddService(&args, &optArgs)
+	_v, err := client.HbacruleAddService(&args, &optArgs)
 	if err != nil {
 		return diag.Errorf("Error creating freeipa the HBAC policy service membership: %s", err)
 	}
+	if _v.Completed == 0 {
+		return diag.Errorf("Error creating freeipa the HBAC policy service membership: %v", _v.Failed)
+	}
+
 	switch svcmember_id {
 	case "sg":
 		id := fmt.Sprintf("%s/sg/%s", d.Get("name").(string), d.Get("servicegroup").(string))

--- a/freeipa/resource_hbac_policy_user_membership.go
+++ b/freeipa/resource_hbac_policy_user_membership.go
@@ -72,10 +72,14 @@ func resourceFreeIPADNSHBACPolicyUserMembershipCreate(ctx context.Context, d *sc
 		user_id = "g"
 	}
 
-	_, err = client.HbacruleAddUser(&args, &optArgs)
+	_v, err := client.HbacruleAddUser(&args, &optArgs)
 	if err != nil {
 		return diag.Errorf("Error creating freeipa the HBAC policy user membership: %s", err)
 	}
+	if _v.Completed == 0 {
+		return diag.Errorf("Error creating freeipa the HBAC policy user membership: %v", _v.Failed)
+	}
+
 	switch user_id {
 	case "g":
 		id := fmt.Sprintf("%s/g/%s", d.Get("name").(string), d.Get("group").(string))

--- a/freeipa/resource_sudo_cmdgroup_membership.go
+++ b/freeipa/resource_sudo_cmdgroup_membership.go
@@ -56,9 +56,12 @@ func resourceFreeIPASudocmdgroupMembershipCreate(ctx context.Context, d *schema.
 		optArgs.Sudocmd = &v
 	}
 
-	_, err = client.SudocmdgroupAddMember(&args, &optArgs)
+	_v, err := client.SudocmdgroupAddMember(&args, &optArgs)
 	if err != nil {
 		return diag.Errorf("Error creating freeipa sudo command group membership: %s", err)
+	}
+	if _v.Completed == 0 {
+		return diag.Errorf("Error creating freeipa sudo command group membership: %v", _v.Failed)
 	}
 
 	id := fmt.Sprintf("%s/sc/%s", d.Get("name").(string), d.Get("sudocmd").(string))

--- a/freeipa/resource_sudo_rule_allowcmd_membership.go
+++ b/freeipa/resource_sudo_rule_allowcmd_membership.go
@@ -72,9 +72,12 @@ func resourceFreeIPASudoRuleAllowCommandMembershipCreate(ctx context.Context, d 
 		cmd_id = "sracg"
 	}
 
-	_, err = client.SudoruleAddAllowCommand(&args, &optArgs)
+	_v, err := client.SudoruleAddAllowCommand(&args, &optArgs)
 	if err != nil {
 		return diag.Errorf("Error creating freeipa sudo rule allowed command membership: %s", err)
+	}
+	if _v.Completed == 0 {
+		return diag.Errorf("Error creating freeipa sudo rule allowed command membership: %v", _v.Failed)
 	}
 
 	switch cmd_id {

--- a/freeipa/resource_sudo_rule_denycmd_membership.go
+++ b/freeipa/resource_sudo_rule_denycmd_membership.go
@@ -72,9 +72,12 @@ func resourceFreeIPASudoRuleDenyCommandMembershipCreate(ctx context.Context, d *
 		cmd_id = "srdcg"
 	}
 
-	_, err = client.SudoruleAddDenyCommand(&args, &optArgs)
+	_v, err := client.SudoruleAddDenyCommand(&args, &optArgs)
 	if err != nil {
 		return diag.Errorf("Error creating freeipa sudo rule denied command membership: %s", err)
+	}
+	if _v.Completed == 0 {
+		return diag.Errorf("Error creating freeipa sudo rule denied command membership: %v", _v.Failed)
 	}
 
 	switch cmd_id {

--- a/freeipa/resource_sudo_rule_host_membership.go
+++ b/freeipa/resource_sudo_rule_host_membership.go
@@ -85,9 +85,12 @@ func resourceFreeIPASudoRuleHostMembershipCreate(ctx context.Context, d *schema.
 	// 	host_id = "srhm"
 	// }
 
-	_, err = client.SudoruleAddHost(&args, &optArgs)
+	_v, err := client.SudoruleAddHost(&args, &optArgs)
 	if err != nil {
 		return diag.Errorf("Error creating freeipa sudo rule host membership: %s", err)
+	}
+	if _v.Completed == 0 {
+		return diag.Errorf("Error creating freeipa sudo rule host membership: %v", _v.Failed)
 	}
 
 	switch host_id {

--- a/freeipa/resource_sudo_rule_runasgroup_membership.go
+++ b/freeipa/resource_sudo_rule_runasgroup_membership.go
@@ -59,9 +59,12 @@ func resourceFreeIPASudoRuleRunAsGroupMembershipCreate(ctx context.Context, d *s
 		group_id = "srraug"
 	}
 
-	_, err = client.SudoruleAddRunasgroup(&args, &optArgs)
+	_v, err := client.SudoruleAddRunasgroup(&args, &optArgs)
 	if err != nil {
 		return diag.Errorf("Error creating freeipa sudo rule runasgroup membership: %s", err)
+	}
+	if _v.Completed == 0 {
+		return diag.Errorf("Error creating freeipa sudo rule runasgroup membership: %v", _v.Failed)
 	}
 
 	switch group_id {

--- a/freeipa/resource_sudo_rule_runasuser_membership.go
+++ b/freeipa/resource_sudo_rule_runasuser_membership.go
@@ -59,9 +59,12 @@ func resourceFreeIPASudoRuleRunAsUserMembershipCreate(ctx context.Context, d *sc
 		user_id = "srrau"
 	}
 
-	_, err = client.SudoruleAddRunasuser(&args, &optArgs)
+	_v, err := client.SudoruleAddRunasuser(&args, &optArgs)
 	if err != nil {
 		return diag.Errorf("Error creating freeipa sudo rule runasuser membership: %s", err)
+	}
+	if _v.Completed == 0 {
+		return diag.Errorf("Error creating freeipa sudo rule runasuser membership: %v", _v.Failed)
 	}
 
 	switch user_id {

--- a/freeipa/resource_sudo_rule_user_membership.go
+++ b/freeipa/resource_sudo_rule_user_membership.go
@@ -72,9 +72,12 @@ func resourceFreeIPASudoRuleUserMembershipCreate(ctx context.Context, d *schema.
 		user_id = "srug"
 	}
 
-	_, err = client.SudoruleAddUser(&args, &optArgs)
+	_v, err := client.SudoruleAddUser(&args, &optArgs)
 	if err != nil {
 		return diag.Errorf("Error creating freeipa sudo rule user membership: %s", err)
+	}
+	if _v.Completed == 0 {
+		return diag.Errorf("Error creating freeipa sudo rule user membership: %v", _v.Failed)
 	}
 
 	switch user_id {


### PR DESCRIPTION
some resource can fail without throwing an error. Especially the membership resources.
This PR detects that no change is applied on create action when no error is returned.

Is this the behavior we want? are there legit usecases when creating a resource can fail silently?