### PR TITLE
Fix deprecation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v3.0.0
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           # GitHub sets this automatically


### PR DESCRIPTION
DEPRECATED: --rm-dist was deprecated in favor of --clean, check [https://goreleaser.com/deprecations#-rm-dist](https://goreleaser.com/deprecations#-rm-dist) for more details