### PR TITLE
Add external idp attributes to user resource and data source

### DIFF
--- a/docs/data-sources/user.md
+++ b/docs/data-sources/user.md
@@ -67,3 +67,4 @@ data "freeipa_user" "user-0" {
 - `uid_number` (Number) User ID Number (system will assign one if not provided)
 - `user_password` (String, Sensitive) User password
 - `userclass` (List of String) User category (semantics placed on this attribute are for local interpretation)
+- `external_idp_username` (String) External IDP Username (for use when users will authenticate via external IDP)

--- a/docs/data-sources/user.md
+++ b/docs/data-sources/user.md
@@ -67,4 +67,5 @@ data "freeipa_user" "user-0" {
 - `uid_number` (Number) User ID Number (system will assign one if not provided)
 - `user_password` (String, Sensitive) User password
 - `userclass` (List of String) User category (semantics placed on this attribute are for local interpretation)
-- `external_idp_username` (String) External IDP Username (for use when users will authenticate via external IDP)
+- `external_idp_username` (String) External IDP username (for use when users will authenticate via external IDP)
+- `external_idp_config` (String) External IDP Configuration name (for use when users will authenticate via external IDP)

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -65,6 +65,7 @@ resource "freeipa_user" "user-1" {
 - `userclass` (List of String) User category (semantics placed on this attribute are for local interpretation)
 - `userpassword` (String, Sensitive) Prompt to set the user password
 - `external_idp_username` (String) External IDP Username (for use when users will authenticate via external IDP)
+- `external_idp_config` (String) External IDP Configuration name (for use when users will authenticate via external IDP)
 
 ### Read-Only
 

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -64,6 +64,7 @@ resource "freeipa_user" "user-1" {
 - `uid_number` (Number) User ID Number (system will assign one if not provided)
 - `userclass` (List of String) User category (semantics placed on this attribute are for local interpretation)
 - `userpassword` (String, Sensitive) Prompt to set the user password
+- `external_idp_username` (String) External IDP Username (for use when users will authenticate via external IDP)
 
 ### Read-Only
 

--- a/freeipa/user_resource.go
+++ b/freeipa/user_resource.go
@@ -70,6 +70,7 @@ type UserResourceModel struct {
 	CarLicense             types.List   `tfsdk:"car_license"`
 	UserClass              types.List   `tfsdk:"userclass"`
 	ExternalIDPUsername    types.String `tfsdk:"ipaidpsub"`
+	ExternalIDPConfig      types.String `tfsdk:"ipaidpconfiglink"`
 }
 
 func (r *UserResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -438,6 +439,14 @@ func (r *UserResource) Create(ctx context.Context, req resource.CreateRequest, r
 		}
 		optArgs.Externalidpusername = &v
 	}	
+	if len(data.ExternalIDPConfig.Elements()) > 0 {
+		var v []string
+		for _, value := range data.ExternalIDPConfig.Elements() {
+			val, _ := strconv.Unquote(value.String())
+			v = append(v, val)
+		}
+		optArgs.Externalidpconfig = &v
+	}	
 
 	if resp.Diagnostics.HasError() {
 		return
@@ -592,6 +601,9 @@ func (r *UserResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	if res.Result.Externalidpusername != nil && !data.ExternalIDPUsername.IsNull() {
 		data.ExternalIDPUsername, _ = types.ListValueFrom(ctx, types.StringType, res.Result.Externalidpusername)
 	}	
+	if res.Result.Externalidpconfig != nil && !data.ExternalIDPConfig.IsNull() {
+		data.ExternalIDPConfig, _ = types.ListValueFrom(ctx, types.StringType, res.Result.Externalidpconfig)
+	}		
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -774,6 +786,14 @@ func (r *UserResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		}
 		optArgs.Externalidpusername = &v
 	}	
+	if !data.ExternalIDPConfig.Equal(state.ExternalIDPConfig) {
+		var v []string
+		for _, value := range data.ExternalIDPConfig.Elements() {
+			val, _ := strconv.Unquote(value.String())
+			v = append(v, val)
+		}
+		optArgs.Externalidpconfig = &v
+	}		
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/freeipa/user_resource.go
+++ b/freeipa/user_resource.go
@@ -69,6 +69,7 @@ type UserResourceModel struct {
 	SshPublicKeys          types.List   `tfsdk:"ssh_public_key"`
 	CarLicense             types.List   `tfsdk:"car_license"`
 	UserClass              types.List   `tfsdk:"userclass"`
+	ExternalIDPUsername    types.String `tfsdk:"ipaidpsub"`
 }
 
 func (r *UserResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -247,6 +248,10 @@ func (r *UserResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 				Optional:            true,
 				ElementType:         types.StringType,
 			},
+			"external_idp_username": schema.StringAttribute{
+				MarkdownDescription: "External IDP Username",
+				Optional:            true,
+			},			
 		},
 	}
 }
@@ -425,6 +430,14 @@ func (r *UserResource) Create(ctx context.Context, req resource.CreateRequest, r
 		}
 		optArgs.Userclass = &v
 	}
+	if len(data.ExternalIDPUsername.Elements()) > 0 {
+		var v []string
+		for _, value := range data.ExternalIDPUsername.Elements() {
+			val, _ := strconv.Unquote(value.String())
+			v = append(v, val)
+		}
+		optArgs.Externalidpusername = &v
+	}	
 
 	if resp.Diagnostics.HasError() {
 		return
@@ -576,6 +589,9 @@ func (r *UserResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	if res.Result.Userclass != nil && !data.UserClass.IsNull() {
 		data.UserClass, _ = types.ListValueFrom(ctx, types.StringType, res.Result.Userclass)
 	}
+	if res.Result.Externalidpusername != nil && !data.ExternalIDPUsername.IsNull() {
+		data.ExternalIDPUsername, _ = types.ListValueFrom(ctx, types.StringType, res.Result.Externalidpusername)
+	}	
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -750,6 +766,14 @@ func (r *UserResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		}
 		optArgs.Userclass = &v
 	}
+	if !data.ExternalIDPUsername.Equal(state.ExternalIDPUsername) {
+		var v []string
+		for _, value := range data.ExternalIDPUsername.Elements() {
+			val, _ := strconv.Unquote(value.String())
+			v = append(v, val)
+		}
+		optArgs.Externalidpusername = &v
+	}	
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/freeipa/user_resource.go
+++ b/freeipa/user_resource.go
@@ -253,6 +253,11 @@ func (r *UserResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 				MarkdownDescription: "External IDP Username",
 				Optional:            true,
 			},			
+      ,
+			"external_idp_config": schema.StringAttribute{
+				MarkdownDescription: "External IDP Config",
+				Optional:            true,
+			},		      
 		},
 	}
 }

--- a/freeipa/user_test.go
+++ b/freeipa/user_test.go
@@ -48,6 +48,7 @@ func TestAccFreeIPAUser_full(t *testing.T) {
 		"krb_principal_expiration": "\"2049-12-31T23:59:59Z\"",
 		"userclass":                "[\"user-account\"]",
 		"external_idp_username":    "\"testacc-user-remote\"",
+		"external_idp_config":      "\"remote-idp-name\"",
 	}
 	testUserModified := map[string]string{
 		"index":                    "1",
@@ -84,6 +85,7 @@ func TestAccFreeIPAUser_full(t *testing.T) {
 		"krb_principal_expiration": "\"2050-12-31T23:59:59Z\"",
 		"userclass":                "[\"unprivileged-user-account\"]",
 		"external_idp_username":    "\"testacc-user-remote\"",
+		"external_idp_config":      "\"remote-idp-name\"",
 	}
 	testUserModified2 := map[string]string{
 		"index":                    "1",
@@ -120,6 +122,7 @@ func TestAccFreeIPAUser_full(t *testing.T) {
 		"krb_principal_expiration": "\"2050-12-31T23:59:59Z\"",
 		"userclass":                "[\"unprivileged-user-account\"]",
 		"external_idp_username":    "\"testacc-user-remote\"",
+		"external_idp_config":      "\"remote-idp-name\"",
 	}
 	testUserDS := map[string]string{
 		"index": "1",
@@ -193,7 +196,8 @@ func TestAccFreeIPAUser_full(t *testing.T) {
 					resource.TestCheckResourceAttr("freeipa_user.user-1", "krb_principal_expiration", "2050-12-31T23:59:59Z"),
 					resource.TestCheckResourceAttr("freeipa_user.user-1", "userclass.#", "1"),
 					resource.TestCheckResourceAttr("freeipa_user.user-1", "userclass.0", "unprivileged-user-account"),
-					resource.TestCheckResourceAttr("freeipa_user.user-1", "external_idp_user", "testacc-user-remote"),
+					resource.TestCheckResourceAttr("freeipa_user.user-1", "external_idp_username", "testacc-user-remote"),
+					resource.TestCheckResourceAttr("freeipa_user.user-1", "external_idp_config", "remote-idp-name"),
 				),
 			},
 			{
@@ -235,7 +239,8 @@ func TestAccFreeIPAUser_full(t *testing.T) {
 					resource.TestCheckResourceAttr("freeipa_user.user-1", "krb_principal_expiration", "2050-12-31T23:59:59Z"),
 					resource.TestCheckResourceAttr("freeipa_user.user-1", "userclass.#", "1"),
 					resource.TestCheckResourceAttr("freeipa_user.user-1", "userclass.0", "unprivileged-user-account"),
-					resource.TestCheckResourceAttr("freeipa_user.user-1", "external_idp_user", "testacc-user-remote"),
+					resource.TestCheckResourceAttr("freeipa_user.user-1", "external_idp_username", "testacc-user-remote"),
+					resource.TestCheckResourceAttr("freeipa_user.user-1", "external_idp_config", "remote-idp-name"),
 				),
 			},
 		},

--- a/freeipa/user_test.go
+++ b/freeipa/user_test.go
@@ -47,6 +47,7 @@ func TestAccFreeIPAUser_full(t *testing.T) {
 		"userpassword":             "\"P@ssword\"",
 		"krb_principal_expiration": "\"2049-12-31T23:59:59Z\"",
 		"userclass":                "[\"user-account\"]",
+		"external_idp_username":    "\"testacc-user-remote\"",
 	}
 	testUserModified := map[string]string{
 		"index":                    "1",
@@ -82,6 +83,7 @@ func TestAccFreeIPAUser_full(t *testing.T) {
 		"userpassword":             "\"Password\"",
 		"krb_principal_expiration": "\"2050-12-31T23:59:59Z\"",
 		"userclass":                "[\"unprivileged-user-account\"]",
+		"external_idp_username":    "\"testacc-user-remote\"",
 	}
 	testUserModified2 := map[string]string{
 		"index":                    "1",
@@ -117,6 +119,7 @@ func TestAccFreeIPAUser_full(t *testing.T) {
 		"userpassword":             "\"Password\"",
 		"krb_principal_expiration": "\"2050-12-31T23:59:59Z\"",
 		"userclass":                "[\"unprivileged-user-account\"]",
+		"external_idp_username":    "\"testacc-user-remote\"",
 	}
 	testUserDS := map[string]string{
 		"index": "1",
@@ -190,6 +193,7 @@ func TestAccFreeIPAUser_full(t *testing.T) {
 					resource.TestCheckResourceAttr("freeipa_user.user-1", "krb_principal_expiration", "2050-12-31T23:59:59Z"),
 					resource.TestCheckResourceAttr("freeipa_user.user-1", "userclass.#", "1"),
 					resource.TestCheckResourceAttr("freeipa_user.user-1", "userclass.0", "unprivileged-user-account"),
+					resource.TestCheckResourceAttr("freeipa_user.user-1", "external_idp_user", "testacc-user-remote"),
 				),
 			},
 			{
@@ -231,6 +235,7 @@ func TestAccFreeIPAUser_full(t *testing.T) {
 					resource.TestCheckResourceAttr("freeipa_user.user-1", "krb_principal_expiration", "2050-12-31T23:59:59Z"),
 					resource.TestCheckResourceAttr("freeipa_user.user-1", "userclass.#", "1"),
 					resource.TestCheckResourceAttr("freeipa_user.user-1", "userclass.0", "unprivileged-user-account"),
+					resource.TestCheckResourceAttr("freeipa_user.user-1", "external_idp_user", "testacc-user-remote"),
 				),
 			},
 		},


### PR DESCRIPTION
Adds ability to use `ipaidpsub` to set an external idp username and `ipaidpconfiglink` to set external idp config.