### PR TITLE
TLS cacert handling

### DIFF
--- a/freeipa/provider.go
+++ b/freeipa/provider.go
@@ -151,7 +151,7 @@ func (p *freeipaProvider) Configure(ctx context.Context, req provider.ConfigureR
 		)
 	}
 
-	if config.InsecureSkipVerify.IsNull() {
+	if config.InsecureSkipVerify.ValueBool() {
 		resp.Diagnostics.AddAttributeWarning(
 			path.Root("insecure"),
 			"FreeIPA InsecureSkipVerify set to TRUE",


### PR DESCRIPTION
@infra-monkey I have updated the FreeIPA client configuration to enhance its certificate validation process. In cases where no specific Certificate Authority (CA) certificate is provided, the system will now default to using the host’s root CA certificates. This adjustment is particularly beneficial when using certificates issued by recognized organizations rather than self-signed certificates