### PR TITLE
fix: some attributes are case insensitive, freeipa lower cases them leading to mismatch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ terraform-provider-freeipa-2
 terraform-provider-freeipa
 .env
 test/
+test-migv4/

--- a/_about/CONTRIBUTING.md
+++ b/_about/CONTRIBUTING.md
@@ -111,3 +111,9 @@ You should get a response from the FreeIPA API server that contains the server v
 ```shell
 {"result": {"result": {"version": "4.10.1"}, "count": 1, "total": 120, "summary": null, "messages": [{"type": "warning", "name": "VersionMissing", "message": "API Version number was not sent, forward compatibility not guaranteed. Assuming server's API version, 2.251", "code": 13001, "data": {"server_version": "2.251"}}]}, "error": null, "id": 0, "principal": "admin@IPATEST.LAN", "version": "4.10.1"}
 ```
+### Run individual acceptance test
+Once the environment is set, you can run a specific test with this command (example for `TestAccFreeIPASudoRuleAllowCmdMembership_CaseInsensitive`)
+
+```shell
+TF_ACC=1 /usr/local/go/bin/go test -timeout 30s -run ^TestAccFreeIPASudoRuleAllowCmdMembership_CaseInsensitive$ github.com/rework-space-com/terraform-provider-freeipa/freeipa
+```

--- a/docs/data-sources/group.md
+++ b/docs/data-sources/group.md
@@ -24,6 +24,11 @@ data "freeipa_group" "group-0" {
 
 - `name` (String) Group name
 
+	- The name must not exceed 32 characters.
+	- The name must contain only lowercase letters (a-z), digits (0-9), and the characters (. - _).
+	- The name must not start with a special character.
+	- A user and a group cannot have the same name.
+
 ### Read-Only
 
 - `description` (String) Group Description

--- a/docs/data-sources/host.md
+++ b/docs/data-sources/host.md
@@ -22,7 +22,10 @@ data "freeipa_host" "host-0" {
 
 ### Required
 
-- `name` (String) Host name
+- `name` (String) Host fully qualified name
+
+	- May contain only letters, numbers, '-'.
+	- DNS label may not start or end with '-'
 
 ### Optional
 

--- a/docs/data-sources/user.md
+++ b/docs/data-sources/user.md
@@ -24,7 +24,12 @@ data "freeipa_user" "user-0" {
 
 ### Required
 
-- `name` (String) UID or login
+- `name` (String) UID or Login
+
+	- The name must not exceed 32 characters.
+	- The name must contain only lowercase letters (a-z), digits (0-9), and the characters (. - _).
+	- The name must not start with a special character.
+	- A user and a group cannot have the same name.
 
 ### Read-Only
 

--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -40,6 +40,11 @@ resource "freeipa_group" "group-external" {
 
 - `name` (String) Group name
 
+	- The name must not exceed 32 characters.
+	- The name must contain only lowercase letters (a-z), digits (0-9), and the characters (. - _).
+	- The name must not start with a special character.
+	- A user and a group cannot have the same name.
+
 ### Optional
 
 - `addattr` (List of String) Add an attribute/value pair. Format is attr=value. The attribute must be part of the schema.

--- a/docs/resources/host.md
+++ b/docs/resources/host.md
@@ -28,7 +28,10 @@ resource "freeipa_host" "host-1" {
 ### Required
 
 - `ip_address` (String) IP address of the host
-- `name` (String) Host name
+- `name` (String) Host fully qualified name
+
+	- May contain only letters, numbers, '-'.
+	- DNS label may not start or end with '-'
 
 ### Optional
 

--- a/docs/resources/sudo_cmd.md
+++ b/docs/resources/sudo_cmd.md
@@ -25,7 +25,7 @@ resource "freeipa_sudo_cmd" "bash" {
 
 ### Required
 
-- `name` (String) Absolute path of the sudo command
+- `name` (String) Absolute path of the sudo command (case sensitive)
 
 ### Optional
 

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -30,7 +30,12 @@ resource "freeipa_user" "user-1" {
 
 - `first_name` (String) First name
 - `last_name` (String) Last name
-- `name` (String) UID or login
+- `name` (String) UID or Login
+
+	- The name must not exceed 32 characters.
+	- The name must contain only lowercase letters (a-z), digits (0-9), and the characters (. - _).
+	- The name must not start with a special character.
+	- A user and a group cannot have the same name.
 
 ### Optional
 

--- a/freeipa/dns_record_test.go
+++ b/freeipa/dns_record_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 func TestAccFreeIPADNSRecord_A(t *testing.T) {
@@ -31,9 +32,46 @@ func TestAccFreeIPADNSRecord_A(t *testing.T) {
 			},
 			{
 				Config: testAccFreeIPAProvider() + testAccFreeIPADNSZone_resource(testZone) + testAccFreeIPADNSRecord_resource(testRecord),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccFreeIPADNSRecord_A_CaseSensitive(t *testing.T) {
+	testZone := map[string]string{
+		"index":     "0",
+		"zone_name": "\"ipa.example.lan\"",
+	}
+	testRecord := map[string]string{
+		"index":     "0",
+		"zone_name": "resource.freeipa_dns_zone.dns-zone-0.id",
+		"type":      "\"A\"",
+		"name":      "\"Test-Record\"",
+		"records":   "[\"192.168.10.10\", \"192.168.10.11\"]",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPADNSZone_resource(testZone) + testAccFreeIPADNSRecord_resource(testRecord),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("freeipa_dns_record.dns-record-0", "name", "test-record"),
+					resource.TestCheckResourceAttr("freeipa_dns_record.dns-record-0", "name", "Test-Record"),
 				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPADNSZone_resource(testZone) + testAccFreeIPADNSRecord_resource(testRecord),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 		},
 	})
@@ -64,9 +102,46 @@ func TestAccFreeIPADNSRecord_CNAME(t *testing.T) {
 			},
 			{
 				Config: testAccFreeIPAProvider() + testAccFreeIPADNSZone_resource(testZone) + testAccFreeIPADNSRecord_resource(testRecord),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccFreeIPADNSRecord_CNAME_CaseSensitive(t *testing.T) {
+	testZone := map[string]string{
+		"index":     "0",
+		"zone_name": "\"ipa.example.lan\"",
+	}
+	testRecord := map[string]string{
+		"index":     "0",
+		"zone_name": "resource.freeipa_dns_zone.dns-zone-0.id",
+		"name":      "\"Test-CNAME\"",
+		"type":      "\"CNAME\"",
+		"records":   "[\"test-record.ipa.example.lan.\"]",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPADNSZone_resource(testZone) + testAccFreeIPADNSRecord_resource(testRecord),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("freeipa_dns_record.dns-record-0", "name", "test-cname"),
+					resource.TestCheckResourceAttr("freeipa_dns_record.dns-record-0", "name", "Test-CNAME"),
 				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPADNSZone_resource(testZone) + testAccFreeIPADNSRecord_resource(testRecord),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 		},
 	})

--- a/freeipa/dns_zone_test.go
+++ b/freeipa/dns_zone_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 func TestAccFreeIPADNSZone_basic(t *testing.T) {
@@ -28,9 +29,63 @@ func TestAccFreeIPADNSZone_basic(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPADNSZone_resource(testZone),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			{
 				Config: testAccFreeIPAProvider() + testAccFreeIPADNSZone_resource(testZoneModified),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("freeipa_dns_zone.dns-zone-0", "computed_zone_name", "ipa.example.lan."),
+				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPADNSZone_resource(testZoneModified),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccFreeIPADNSZone_basic_CaseInsensitive(t *testing.T) {
+	testZone := map[string]string{
+		"index":     "0",
+		"zone_name": "\"IPA.example.lan\"",
+	}
+	testZoneDS := map[string]string{
+		"index":     "0",
+		"zone_name": "\"IPA.example.lan.\"",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPADNSZone_resource(testZone),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("freeipa_dns_zone.dns-zone-0", "computed_zone_name", "ipa.example.lan."),
+				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPADNSZone_resource(testZone),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPADNSZone_resource(testZone) + testAccFreeIPADNSZone_datasource(testZoneDS),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.freeipa_dns_zone.dns-zone-0", "zone_name", "ipa.example.lan."),
 				),
 			},
 		},
@@ -57,6 +112,14 @@ func TestAccFreeIPADNSZone_reverse(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("freeipa_dns_zone.dns-zone-0", "computed_zone_name", "23.168.192.in-addr.arpa."),
 				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPADNSZone_resource(testZone),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 			{
 				Config: testAccFreeIPAProvider() + testAccFreeIPADNSZone_resource(testZone) + testAccFreeIPADNSZone_datasource(testDS),

--- a/freeipa/group_data_source.go
+++ b/freeipa/group_data_source.go
@@ -62,7 +62,7 @@ func (r *UserGroupDataSource) Schema(ctx context.Context, req datasource.SchemaR
 				Computed:            true,
 			},
 			"name": schema.StringAttribute{
-				MarkdownDescription: "Group name",
+				MarkdownDescription: "Group name\n\n	- The name must not exceed 32 characters.\n	- The name must contain only lowercase letters (a-z), digits (0-9), and the characters (. - _).\n	- The name must not start with a special character.\n	- A user and a group cannot have the same name.",
 				Required:            true,
 			},
 			"description": schema.StringAttribute{

--- a/freeipa/group_resource.go
+++ b/freeipa/group_resource.go
@@ -82,7 +82,7 @@ func (r *UserGroupResource) Schema(ctx context.Context, req resource.SchemaReque
 				},
 			},
 			"name": schema.StringAttribute{
-				MarkdownDescription: "Group name",
+				MarkdownDescription: "Group name\n\n	- The name must not exceed 32 characters.\n	- The name must contain only lowercase letters (a-z), digits (0-9), and the characters (. - _).\n	- The name must not start with a special character.\n	- A user and a group cannot have the same name.",
 				Required:            true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),

--- a/freeipa/group_resource.go
+++ b/freeipa/group_resource.go
@@ -217,7 +217,7 @@ func (r *UserGroupResource) Create(ctx context.Context, req resource.CreateReque
 
 	tflog.Trace(ctx, "created a user group resource")
 
-	data.Id = types.StringValue(data.Name.ValueString())
+	data.Id = types.StringValue(ret.Result.Cn)
 
 	if resp.Diagnostics.HasError() {
 		return
@@ -263,8 +263,6 @@ func (r *UserGroupResource) Read(ctx context.Context, req resource.ReadRequest, 
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Error reading freeipa group %s", data.Name.ValueString()))
 		return
 	}
-
-	data.Name = types.StringValue(res.Result.Cn)
 	tflog.Debug(ctx, fmt.Sprintf("[DEBUG] Read freeipa group Cn %s", data.Name.ValueString()))
 	if res.Result.Description != nil && !data.Description.IsNull() {
 		data.Description = types.StringValue(*res.Result.Description)

--- a/freeipa/group_test.go
+++ b/freeipa/group_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 func TestAccFreeIPAGroup_posix(t *testing.T) {
@@ -40,6 +41,14 @@ func TestAccFreeIPAGroup_posix(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAGroup_resource(testGroup),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			{
 				Config: testAccFreeIPAProvider() + testAccFreeIPAGroup_resource(testGroup) + testAccFreeIPAGroup_resource(testGroup2) + testAccFreeIPAGroup_datasource(testGroupDS),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.freeipa_group.group-1", "description", "User group test 2"),
@@ -47,6 +56,81 @@ func TestAccFreeIPAGroup_posix(t *testing.T) {
 					resource.TestCheckResourceAttr("freeipa_group.group-2", "description", "User group test 2"),
 					resource.TestCheckResourceAttr("freeipa_group.group-2", "gid_number", "10002"),
 				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAGroup_resource(testGroup) + testAccFreeIPAGroup_resource(testGroup2) + testAccFreeIPAGroup_datasource(testGroupDS),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccFreeIPAGroup_posix_CaseInsensitive(t *testing.T) {
+	testGroup := map[string]string{
+		"index":       "1",
+		"name":        "\"TestACC-Group-1\"",
+		"description": "\"Test group 1\"",
+		"gid_number":  "10000",
+		"addattr":     "[\"owner=uid=test\"]",
+		"setattr":     "[\"owner=uid=test\"]",
+	}
+	testGroup2 := map[string]string{
+		"index":       "2",
+		"name":        "\"TestACC-GroupPos-2\"",
+		"description": "\"User group test 2\"",
+		"gid_number":  "10002",
+		"addattr":     "[\"owner=uid=test2\"]",
+		"setattr":     "[\"owner=uid=test\"]",
+	}
+	testGroupDS := map[string]string{
+		"index": "1",
+		"name":  "freeipa_group.group-2.name",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAGroup_resource(testGroup),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("freeipa_group.group-1", "id", "testacc-group-1"),
+					resource.TestCheckResourceAttr("freeipa_group.group-1", "name", "TestACC-Group-1"),
+					resource.TestCheckResourceAttr("freeipa_group.group-1", "description", "Test group 1"),
+					resource.TestCheckResourceAttr("freeipa_group.group-1", "gid_number", "10000"),
+				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAGroup_resource(testGroup),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAGroup_resource(testGroup) + testAccFreeIPAGroup_resource(testGroup2) + testAccFreeIPAGroup_datasource(testGroupDS),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.freeipa_group.group-1", "name", "testacc-grouppos-2"),
+					resource.TestCheckResourceAttr("data.freeipa_group.group-1", "description", "User group test 2"),
+					resource.TestCheckResourceAttr("data.freeipa_group.group-1", "gid_number", "10002"),
+					resource.TestCheckResourceAttr("freeipa_group.group-2", "id", "testacc-grouppos-2"),
+					resource.TestCheckResourceAttr("freeipa_group.group-2", "name", "TestACC-GroupPos-2"),
+					resource.TestCheckResourceAttr("freeipa_group.group-2", "description", "User group test 2"),
+					resource.TestCheckResourceAttr("freeipa_group.group-2", "gid_number", "10002"),
+				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAGroup_resource(testGroup) + testAccFreeIPAGroup_resource(testGroup2) + testAccFreeIPAGroup_datasource(testGroupDS),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 		},
 	})
@@ -69,9 +153,52 @@ func TestAccFreeIPAGroup_noposix(t *testing.T) {
 			{
 				Config: testAccFreeIPAProvider() + testAccFreeIPAGroup_resource(testGroup),
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("freeipa_group.group-1", "id", "testacc-groupnonpos"),
 					resource.TestCheckResourceAttr("freeipa_group.group-1", "name", "testacc-groupnonpos"),
 					resource.TestCheckResourceAttr("freeipa_group.group-1", "description", "User group test"),
 				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAGroup_resource(testGroup),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccFreeIPAGroup_noposix_CaseInsensitive(t *testing.T) {
+	testGroup := map[string]string{
+		"index":       "1",
+		"name":        "\"TestACC-groupnonpos\"",
+		"description": "\"User group test\"",
+		"nonposix":    "true",
+		"addattr":     "[\"owner=uid=test\"]",
+		"setattr":     "[\"owner=uid=test\"]",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAGroup_resource(testGroup),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("freeipa_group.group-1", "id", "testacc-groupnonpos"),
+					resource.TestCheckResourceAttr("freeipa_group.group-1", "name", "TestACC-groupnonpos"),
+					resource.TestCheckResourceAttr("freeipa_group.group-1", "description", "User group test"),
+				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAGroup_resource(testGroup),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 		},
 	})
@@ -94,9 +221,52 @@ func TestAccFreeIPAGroup_external(t *testing.T) {
 			{
 				Config: testAccFreeIPAProvider() + testAccFreeIPAGroup_resource(testGroup),
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("freeipa_group.group-1", "id", "testacc-groupext"),
 					resource.TestCheckResourceAttr("freeipa_group.group-1", "name", "testacc-groupext"),
 					resource.TestCheckResourceAttr("freeipa_group.group-1", "description", "External user group test"),
 				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAGroup_resource(testGroup),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccFreeIPAGroup_external_CaseInsensitive(t *testing.T) {
+	testGroup := map[string]string{
+		"index":       "1",
+		"name":        "\"TestACC-groupext\"",
+		"description": "\"External user group test\"",
+		"external":    "true",
+		"addattr":     "[\"owner=uid=test\"]",
+		"setattr":     "[\"owner=uid=test\"]",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAGroup_resource(testGroup),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("freeipa_group.group-1", "id", "testacc-groupext"),
+					resource.TestCheckResourceAttr("freeipa_group.group-1", "name", "TestACC-groupext"),
+					resource.TestCheckResourceAttr("freeipa_group.group-1", "description", "External user group test"),
+				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAGroup_resource(testGroup),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 		},
 	})

--- a/freeipa/hbac_policy_host_membership_resource.go
+++ b/freeipa/hbac_policy_host_membership_resource.go
@@ -261,13 +261,13 @@ func (r *HbacPolicyHostMembershipResource) Read(ctx context.Context, req resourc
 
 	switch typeId {
 	case "h":
-		if res.Result.MemberhostHost == nil || !slices.Contains(*res.Result.MemberhostHost, policyId) {
+		if res.Result.MemberhostHost == nil || !isStringListContainsCaseInsensistive(res.Result.MemberhostHost, &policyId) {
 			tflog.Debug(ctx, "[DEBUG] HBAC policy host membership does not exist")
 			resp.State.RemoveResource(ctx)
 			return
 		}
 	case "hg":
-		if res.Result.MemberhostHostgroup == nil || !slices.Contains(*res.Result.MemberhostHostgroup, policyId) {
+		if res.Result.MemberhostHostgroup == nil || !isStringListContainsCaseInsensistive(res.Result.MemberhostHostgroup, &policyId) {
 			tflog.Debug(ctx, "[DEBUG] HBAC policy host group membership does not exist")
 			resp.State.RemoveResource(ctx)
 			return
@@ -280,7 +280,7 @@ func (r *HbacPolicyHostMembershipResource) Read(ctx context.Context, req resourc
 				if err != nil {
 					tflog.Debug(ctx, fmt.Sprintf("[DEBUG] Read freeipa hbac policy host member failed with error %s", err))
 				}
-				if res.Result.MemberhostHost != nil && slices.Contains(*res.Result.MemberhostHost, val) {
+				if res.Result.MemberhostHost != nil && isStringListContainsCaseInsensistive(res.Result.MemberhostHost, &val) {
 					tflog.Debug(ctx, fmt.Sprintf("[DEBUG] Read freeipa hbac policy host member %s is present in results", val))
 					changedVals = append(changedVals, val)
 				}
@@ -298,7 +298,7 @@ func (r *HbacPolicyHostMembershipResource) Read(ctx context.Context, req resourc
 				if err != nil {
 					tflog.Debug(ctx, fmt.Sprintf("[DEBUG] Read freeipa hbac policy member commands failed with error %s", err))
 				}
-				if res.Result.MemberhostHostgroup != nil && slices.Contains(*res.Result.MemberhostHostgroup, val) {
+				if res.Result.MemberhostHostgroup != nil && isStringListContainsCaseInsensistive(res.Result.MemberhostHostgroup, &val) {
 					tflog.Debug(ctx, fmt.Sprintf("[DEBUG] Read freeipa hbac policy member commands %s is present in results", val))
 					changedVals = append(changedVals, val)
 				}

--- a/freeipa/hbac_policy_host_membership_test.go
+++ b/freeipa/hbac_policy_host_membership_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 func TestAccFreeIPAHbacPolicyHostMembership_simple(t *testing.T) {
@@ -56,6 +57,14 @@ func TestAccFreeIPAHbacPolicyHostMembership_simple(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPADNSZone_resource(testZone) + testAccFreeIPAHost_resource(testMemberHost) + testAccFreeIPAHostGroup_resource(testHostGroup) + testAccFreeIPAHbacPolicy_resource(testHbacPolicy) + testAccFreeIPAHbacPolicyHostMembership_resource(testHbacHostMembership) + testAccFreeIPAHbacPolicyHostMembership_resource(testHbacHostGrpMembership),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			{
 				Config: testAccFreeIPAProvider() + testAccFreeIPADNSZone_resource(testZone) + testAccFreeIPAHost_resource(testMemberHost) + testAccFreeIPAHostGroup_resource(testHostGroup) + testAccFreeIPAHbacPolicy_resource(testHbacPolicy) + testAccFreeIPAHbacPolicyHostMembership_resource(testHbacHostMembership) + testAccFreeIPAHbacPolicyHostMembership_resource(testHbacHostGrpMembership) + testAccFreeIPAHbacPolicy_datasource(testHbacDS),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.freeipa_hbac_policy.hbacpolicy-1", "name", "testacc-hbac-policy"),
@@ -65,6 +74,94 @@ func TestAccFreeIPAHbacPolicyHostMembership_simple(t *testing.T) {
 					resource.TestCheckResourceAttr("data.freeipa_hbac_policy.hbacpolicy-1", "member_hostgroup.#", "1"),
 					resource.TestCheckResourceAttr("data.freeipa_hbac_policy.hbacpolicy-1", "member_hostgroup.0", "testacc-hostgroup"),
 				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPADNSZone_resource(testZone) + testAccFreeIPAHost_resource(testMemberHost) + testAccFreeIPAHostGroup_resource(testHostGroup) + testAccFreeIPAHbacPolicy_resource(testHbacPolicy) + testAccFreeIPAHbacPolicyHostMembership_resource(testHbacHostMembership) + testAccFreeIPAHbacPolicyHostMembership_resource(testHbacHostGrpMembership) + testAccFreeIPAHbacPolicy_datasource(testHbacDS),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccFreeIPAHbacPolicyHostMembership_simple_CaseInsensitive(t *testing.T) {
+	testZone := map[string]string{
+		"index":     "0",
+		"zone_name": "\"testacc.ipatest.lan\"",
+	}
+	testMemberHost := map[string]string{
+		"index":      "0",
+		"name":       "\"TestACC-Host-1.${freeipa_dns_zone.dns-zone-0.zone_name}\"",
+		"ip_address": "\"192.168.10.65\"",
+	}
+	testHostGroup := map[string]string{
+		"index": "0",
+		"name":  "\"TestACC-HostGroup\"",
+	}
+	testHbacPolicy := map[string]string{
+		"index":       "1",
+		"name":        "\"TestACC-HBAC-Policy\"",
+		"description": "\"A hbac policy for acceptance tests\"",
+	}
+	testHbacHostMembership := map[string]string{
+		"index": "1",
+		"name":  "freeipa_hbac_policy.hbacpolicy-1.name",
+		"host":  "freeipa_host.host-0.name",
+	}
+	testHbacHostGrpMembership := map[string]string{
+		"index":     "2",
+		"name":      "freeipa_hbac_policy.hbacpolicy-1.name",
+		"hostgroup": "freeipa_hostgroup.hostgroup-0.name",
+	}
+	testHbacDS := map[string]string{
+		"index": "1",
+		"name":  "freeipa_hbac_policy.hbacpolicy-1.name",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPADNSZone_resource(testZone) + testAccFreeIPAHost_resource(testMemberHost) + testAccFreeIPAHostGroup_resource(testHostGroup) + testAccFreeIPAHbacPolicy_resource(testHbacPolicy) + testAccFreeIPAHbacPolicyHostMembership_resource(testHbacHostMembership) + testAccFreeIPAHbacPolicyHostMembership_resource(testHbacHostGrpMembership),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("freeipa_hbac_policy.hbacpolicy-1", "name", "TestACC-HBAC-Policy"),
+					resource.TestCheckResourceAttr("freeipa_hbac_policy.hbacpolicy-1", "description", "A hbac policy for acceptance tests"),
+					resource.TestCheckResourceAttr("freeipa_hbac_policy_host_membership.hbac-host-membership-1", "name", "TestACC-HBAC-Policy"),
+					resource.TestCheckResourceAttr("freeipa_hbac_policy_host_membership.hbac-host-membership-1", "host", "TestACC-Host-1.testacc.ipatest.lan"),
+					resource.TestCheckResourceAttr("freeipa_hbac_policy_host_membership.hbac-host-membership-2", "name", "TestACC-HBAC-Policy"),
+					resource.TestCheckResourceAttr("freeipa_hbac_policy_host_membership.hbac-host-membership-2", "hostgroup", "TestACC-HostGroup"),
+				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPADNSZone_resource(testZone) + testAccFreeIPAHost_resource(testMemberHost) + testAccFreeIPAHostGroup_resource(testHostGroup) + testAccFreeIPAHbacPolicy_resource(testHbacPolicy) + testAccFreeIPAHbacPolicyHostMembership_resource(testHbacHostMembership) + testAccFreeIPAHbacPolicyHostMembership_resource(testHbacHostGrpMembership),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPADNSZone_resource(testZone) + testAccFreeIPAHost_resource(testMemberHost) + testAccFreeIPAHostGroup_resource(testHostGroup) + testAccFreeIPAHbacPolicy_resource(testHbacPolicy) + testAccFreeIPAHbacPolicyHostMembership_resource(testHbacHostMembership) + testAccFreeIPAHbacPolicyHostMembership_resource(testHbacHostGrpMembership) + testAccFreeIPAHbacPolicy_datasource(testHbacDS),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.freeipa_hbac_policy.hbacpolicy-1", "name", "TestACC-HBAC-Policy"),
+					resource.TestCheckResourceAttr("data.freeipa_hbac_policy.hbacpolicy-1", "description", "A hbac policy for acceptance tests"),
+					resource.TestCheckResourceAttr("data.freeipa_hbac_policy.hbacpolicy-1", "member_host.#", "1"),
+					resource.TestCheckResourceAttr("data.freeipa_hbac_policy.hbacpolicy-1", "member_host.0", "testacc-host-1.testacc.ipatest.lan"),
+					resource.TestCheckResourceAttr("data.freeipa_hbac_policy.hbacpolicy-1", "member_hostgroup.#", "1"),
+					resource.TestCheckResourceAttr("data.freeipa_hbac_policy.hbacpolicy-1", "member_hostgroup.0", "testacc-hostgroup"),
+				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPADNSZone_resource(testZone) + testAccFreeIPAHost_resource(testMemberHost) + testAccFreeIPAHostGroup_resource(testHostGroup) + testAccFreeIPAHbacPolicy_resource(testHbacPolicy) + testAccFreeIPAHbacPolicyHostMembership_resource(testHbacHostMembership) + testAccFreeIPAHbacPolicyHostMembership_resource(testHbacHostGrpMembership) + testAccFreeIPAHbacPolicy_datasource(testHbacDS),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 		},
 	})
@@ -123,6 +220,14 @@ func TestAccFreeIPAHbacPolicyHostMembership_mutiple(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPADNSZone_resource(testZone) + testAccFreeIPAHost_resource(testMemberHost) + testAccFreeIPAHostGroup_resource(testHostGroup) + testAccFreeIPAHbacPolicy_resource(testHbacPolicy) + testAccFreeIPAHbacPolicyHostMembership_resource(testHbacHostMembership) + testAccFreeIPAHbacPolicyHostMembership_resource(testHbacHostGrpMembership),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			{
 				Config: testAccFreeIPAProvider() + testAccFreeIPADNSZone_resource(testZone) + testAccFreeIPAHost_resource(testMemberHost) + testAccFreeIPAHostGroup_resource(testHostGroup) + testAccFreeIPAHbacPolicy_resource(testHbacPolicy) + testAccFreeIPAHbacPolicyHostMembership_resource(testHbacHostMembership) + testAccFreeIPAHbacPolicyHostMembership_resource(testHbacHostGrpMembership) + testAccFreeIPAHbacPolicy_datasource(testHbacDS),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.freeipa_hbac_policy.hbacpolicy-1", "name", "testacc-hbac-policy"),
@@ -132,6 +237,14 @@ func TestAccFreeIPAHbacPolicyHostMembership_mutiple(t *testing.T) {
 					resource.TestCheckResourceAttr("data.freeipa_hbac_policy.hbacpolicy-1", "member_hostgroup.#", "1"),
 					resource.TestCheckResourceAttr("data.freeipa_hbac_policy.hbacpolicy-1", "member_hostgroup.0", "testacc-hostgroup"),
 				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPADNSZone_resource(testZone) + testAccFreeIPAHost_resource(testMemberHost) + testAccFreeIPAHostGroup_resource(testHostGroup) + testAccFreeIPAHbacPolicy_resource(testHbacPolicy) + testAccFreeIPAHbacPolicyHostMembership_resource(testHbacHostMembership) + testAccFreeIPAHbacPolicyHostMembership_resource(testHbacHostGrpMembership) + testAccFreeIPAHbacPolicy_datasource(testHbacDS),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 		},
 	})

--- a/freeipa/hbac_policy_service_membership_test.go
+++ b/freeipa/hbac_policy_service_membership_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 func TestAccFreeIPAHbacPolicyServiceMembership_simple(t *testing.T) {
@@ -52,6 +53,14 @@ func TestAccFreeIPAHbacPolicyServiceMembership_simple(t *testing.T) {
 					resource.TestCheckResourceAttr("data.freeipa_hbac_policy.hbacpolicy-1", "member_servicegroup.#", "1"),
 					resource.TestCheckResourceAttr("data.freeipa_hbac_policy.hbacpolicy-1", "member_servicegroup.0", "Sudo"),
 				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAHbacPolicy_resource(testHbacPolicy) + testAccFreeIPAHbacPolicyServiceMembership_resource(testHbacServiceMembership) + testAccFreeIPAHbacPolicyServiceMembership_resource(testHbacServiceGroupMembership) + testAccFreeIPAHbacPolicy_datasource(testHbacDS),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 		},
 	})
@@ -106,6 +115,14 @@ func TestAccFreeIPAHbacPolicyServiceMembership_mutiple(t *testing.T) {
 					resource.TestCheckResourceAttr("data.freeipa_hbac_policy.hbacpolicy-1", "member_servicegroup.#", "1"),
 					resource.TestCheckResourceAttr("data.freeipa_hbac_policy.hbacpolicy-1", "member_servicegroup.0", "Sudo"),
 				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAHbacPolicy_resource(testHbacPolicy) + testAccFreeIPAHbacPolicyServiceMembership_resource(testHbacServiceMembership) + testAccFreeIPAHbacPolicyServiceMembership_resource(testHbacServiceGroupMembership) + testAccFreeIPAHbacPolicy_datasource(testHbacDS),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 		},
 	})

--- a/freeipa/hbac_policy_test.go
+++ b/freeipa/hbac_policy_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 func TestAccFreeIPAHbacPolicy_simple(t *testing.T) {
@@ -45,6 +46,14 @@ func TestAccFreeIPAHbacPolicy_simple(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAHbacPolicy_resource(testHbacPolicy) + testAccFreeIPAHbacPolicy_datasource(testHbacPolicyDS),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			{
 				Config: testAccFreeIPAProvider() + testAccFreeIPAHbacPolicy_resource(testHbacPolicyModified),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("freeipa_hbac_policy.hbacpolicy-1", "name", "testacc-hbac-policy"),
@@ -65,6 +74,94 @@ func TestAccFreeIPAHbacPolicy_simple(t *testing.T) {
 					resource.TestCheckResourceAttr("data.freeipa_hbac_policy.hbacpolicy-1", "hostcategory", "all"),
 					resource.TestCheckResourceAttr("data.freeipa_hbac_policy.hbacpolicy-1", "servicecategory", "all"),
 				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAHbacPolicy_resource(testHbacPolicyModified) + testAccFreeIPAHbacPolicy_datasource(testHbacPolicyDS),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccFreeIPAHbacPolicy_simple_CaseSensitive(t *testing.T) {
+	testHbacPolicy := map[string]string{
+		"index":       "1",
+		"name":        "\"Testacc HBAC Policy\"",
+		"description": "\"A hbac policy for acceptance tests\"",
+	}
+	testHbacPolicyModified := map[string]string{
+		"index":           "1",
+		"name":            "\"Testacc HBAC Policy\"",
+		"description":     "\"A new hbac policy for acceptance tests\"",
+		"enabled":         "false",
+		"usercategory":    "\"all\"",
+		"hostcategory":    "\"all\"",
+		"servicecategory": "\"all\"",
+	}
+	testHbacPolicyDS := map[string]string{
+		"index": "1",
+		"name":  "freeipa_hbac_policy.hbacpolicy-1.name",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAHbacPolicy_resource(testHbacPolicy),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("freeipa_hbac_policy.hbacpolicy-1", "name", "Testacc HBAC Policy"),
+					resource.TestCheckResourceAttr("freeipa_hbac_policy.hbacpolicy-1", "description", "A hbac policy for acceptance tests"),
+				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAHbacPolicy_resource(testHbacPolicy) + testAccFreeIPAHbacPolicy_datasource(testHbacPolicyDS),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.freeipa_hbac_policy.hbacpolicy-1", "name", "Testacc HBAC Policy"),
+					resource.TestCheckResourceAttr("data.freeipa_hbac_policy.hbacpolicy-1", "description", "A hbac policy for acceptance tests"),
+				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAHbacPolicy_resource(testHbacPolicy) + testAccFreeIPAHbacPolicy_datasource(testHbacPolicyDS),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAHbacPolicy_resource(testHbacPolicyModified),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("freeipa_hbac_policy.hbacpolicy-1", "name", "Testacc HBAC Policy"),
+					resource.TestCheckResourceAttr("freeipa_hbac_policy.hbacpolicy-1", "description", "A new hbac policy for acceptance tests"),
+					resource.TestCheckResourceAttr("freeipa_hbac_policy.hbacpolicy-1", "enabled", "false"),
+					resource.TestCheckResourceAttr("freeipa_hbac_policy.hbacpolicy-1", "usercategory", "all"),
+					resource.TestCheckResourceAttr("freeipa_hbac_policy.hbacpolicy-1", "hostcategory", "all"),
+					resource.TestCheckResourceAttr("freeipa_hbac_policy.hbacpolicy-1", "servicecategory", "all"),
+				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAHbacPolicy_resource(testHbacPolicyModified) + testAccFreeIPAHbacPolicy_datasource(testHbacPolicyDS),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.freeipa_hbac_policy.hbacpolicy-1", "name", "Testacc HBAC Policy"),
+					resource.TestCheckResourceAttr("data.freeipa_hbac_policy.hbacpolicy-1", "description", "A new hbac policy for acceptance tests"),
+					resource.TestCheckResourceAttr("data.freeipa_hbac_policy.hbacpolicy-1", "enabled", "false"),
+					resource.TestCheckResourceAttr("data.freeipa_hbac_policy.hbacpolicy-1", "usercategory", "all"),
+					resource.TestCheckResourceAttr("data.freeipa_hbac_policy.hbacpolicy-1", "hostcategory", "all"),
+					resource.TestCheckResourceAttr("data.freeipa_hbac_policy.hbacpolicy-1", "servicecategory", "all"),
+				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAHbacPolicy_resource(testHbacPolicyModified) + testAccFreeIPAHbacPolicy_datasource(testHbacPolicyDS),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 		},
 	})

--- a/freeipa/hbac_policy_user_membership_resource.go
+++ b/freeipa/hbac_policy_user_membership_resource.go
@@ -261,13 +261,13 @@ func (r *HbacPolicyUserMembershipResource) Read(ctx context.Context, req resourc
 
 	switch typeId {
 	case "u":
-		if res.Result.MemberuserUser == nil || !slices.Contains(*res.Result.MemberuserUser, policyId) {
+		if res.Result.MemberuserUser == nil || !isStringListContainsCaseInsensistive(res.Result.MemberuserUser, &policyId) {
 			tflog.Debug(ctx, "[DEBUG] HBAC policy user membership does not exist")
 			resp.State.RemoveResource(ctx)
 			return
 		}
 	case "g":
-		if res.Result.MemberuserGroup == nil || !slices.Contains(*res.Result.MemberuserGroup, policyId) {
+		if res.Result.MemberuserGroup == nil || !isStringListContainsCaseInsensistive(res.Result.MemberuserGroup, &policyId) {
 			tflog.Debug(ctx, "[DEBUG] HBAC policy user group membership does not exist")
 			resp.State.RemoveResource(ctx)
 			return
@@ -280,7 +280,7 @@ func (r *HbacPolicyUserMembershipResource) Read(ctx context.Context, req resourc
 				if err != nil {
 					tflog.Debug(ctx, fmt.Sprintf("[DEBUG] Read freeipa hbac policy user member failed with error %s", err))
 				}
-				if res.Result.MemberuserUser != nil && slices.Contains(*res.Result.MemberuserUser, val) {
+				if res.Result.MemberuserUser != nil && isStringListContainsCaseInsensistive(res.Result.MemberuserUser, &val) {
 					tflog.Debug(ctx, fmt.Sprintf("[DEBUG] Read freeipa hbac policy user member %s is present in results", val))
 					changedVals = append(changedVals, val)
 				}
@@ -298,7 +298,7 @@ func (r *HbacPolicyUserMembershipResource) Read(ctx context.Context, req resourc
 				if err != nil {
 					tflog.Debug(ctx, fmt.Sprintf("[DEBUG] Read freeipa hbac policy member commands failed with error %s", err))
 				}
-				if res.Result.MemberuserGroup != nil && slices.Contains(*res.Result.MemberuserGroup, val) {
+				if res.Result.MemberuserGroup != nil && isStringListContainsCaseInsensistive(res.Result.MemberuserGroup, &val) {
 					tflog.Debug(ctx, fmt.Sprintf("[DEBUG] Read freeipa hbac policy member commands %s is present in results", val))
 					changedVals = append(changedVals, val)
 				}

--- a/freeipa/hbac_policy_user_membership_test.go
+++ b/freeipa/hbac_policy_user_membership_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 func TestAccFreeIPAHbacPolicyUserMembership_simple(t *testing.T) {
@@ -63,6 +64,84 @@ func TestAccFreeIPAHbacPolicyUserMembership_simple(t *testing.T) {
 					resource.TestCheckResourceAttr("data.freeipa_hbac_policy.hbacpolicy-1", "member_group.#", "1"),
 					resource.TestCheckResourceAttr("data.freeipa_hbac_policy.hbacpolicy-1", "member_group.0", "testacc-group-0"),
 				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAUser_resource(testMemberUser) + testAccFreeIPAGroup_resource(testGroup) + testAccFreeIPAHbacPolicy_resource(testHbacPolicy) + testAccFreeIPAHbacPolicyUserMembership_resource(testHbacUserMembership) + testAccFreeIPAHbacPolicyUserMembership_resource(testHbacUserGrpMembership) + testAccFreeIPAHbacPolicy_datasource(testHbacDS),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccFreeIPAHbacPolicyUserMembership_simple_CaseInsensitive(t *testing.T) {
+	testGroup := map[string]string{
+		"index":       "0",
+		"name":        "\"TestACC-Group-0\"",
+		"description": "\"User group test 0\"",
+	}
+	testMemberUser := map[string]string{
+		"index":     "0",
+		"login":     "\"TestACC-User-0\"",
+		"firstname": "\"Test\"",
+		"lastname":  "\"User0\"",
+	}
+	testHbacPolicy := map[string]string{
+		"index":       "1",
+		"name":        "\"TestACC-HBAC-Policy\"",
+		"description": "\"A hbac policy for acceptance tests\"",
+	}
+	testHbacUserMembership := map[string]string{
+		"index": "1",
+		"name":  "freeipa_hbac_policy.hbacpolicy-1.name",
+		"user":  "freeipa_user.user-0.name",
+	}
+	testHbacUserGrpMembership := map[string]string{
+		"index": "2",
+		"name":  "freeipa_hbac_policy.hbacpolicy-1.name",
+		"group": "freeipa_group.group-0.name",
+	}
+	testHbacDS := map[string]string{
+		"index": "1",
+		"name":  "freeipa_hbac_policy.hbacpolicy-1.name",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAUser_resource(testMemberUser) + testAccFreeIPAGroup_resource(testGroup) + testAccFreeIPAHbacPolicy_resource(testHbacPolicy) + testAccFreeIPAHbacPolicyUserMembership_resource(testHbacUserMembership) + testAccFreeIPAHbacPolicyUserMembership_resource(testHbacUserGrpMembership),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("freeipa_hbac_policy.hbacpolicy-1", "name", "TestACC-HBAC-Policy"),
+					resource.TestCheckResourceAttr("freeipa_hbac_policy.hbacpolicy-1", "description", "A hbac policy for acceptance tests"),
+					resource.TestCheckResourceAttr("freeipa_hbac_policy_user_membership.hbac-user-membership-1", "name", "TestACC-HBAC-Policy"),
+					resource.TestCheckResourceAttr("freeipa_hbac_policy_user_membership.hbac-user-membership-1", "user", "TestACC-User-0"),
+					resource.TestCheckResourceAttr("freeipa_hbac_policy_user_membership.hbac-user-membership-2", "name", "TestACC-HBAC-Policy"),
+					resource.TestCheckResourceAttr("freeipa_hbac_policy_user_membership.hbac-user-membership-2", "group", "TestACC-Group-0"),
+				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAUser_resource(testMemberUser) + testAccFreeIPAGroup_resource(testGroup) + testAccFreeIPAHbacPolicy_resource(testHbacPolicy) + testAccFreeIPAHbacPolicyUserMembership_resource(testHbacUserMembership) + testAccFreeIPAHbacPolicyUserMembership_resource(testHbacUserGrpMembership) + testAccFreeIPAHbacPolicy_datasource(testHbacDS),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.freeipa_hbac_policy.hbacpolicy-1", "name", "TestACC-HBAC-Policy"),
+					resource.TestCheckResourceAttr("data.freeipa_hbac_policy.hbacpolicy-1", "description", "A hbac policy for acceptance tests"),
+					resource.TestCheckResourceAttr("data.freeipa_hbac_policy.hbacpolicy-1", "member_user.#", "1"),
+					resource.TestCheckResourceAttr("data.freeipa_hbac_policy.hbacpolicy-1", "member_user.0", "testacc-user-0"),
+					resource.TestCheckResourceAttr("data.freeipa_hbac_policy.hbacpolicy-1", "member_group.#", "1"),
+					resource.TestCheckResourceAttr("data.freeipa_hbac_policy.hbacpolicy-1", "member_group.0", "testacc-group-0"),
+				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAUser_resource(testMemberUser) + testAccFreeIPAGroup_resource(testGroup) + testAccFreeIPAHbacPolicy_resource(testHbacPolicy) + testAccFreeIPAHbacPolicyUserMembership_resource(testHbacUserMembership) + testAccFreeIPAHbacPolicyUserMembership_resource(testHbacUserGrpMembership) + testAccFreeIPAHbacPolicy_datasource(testHbacDS),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 		},
 	})
@@ -128,6 +207,87 @@ func TestAccFreeIPAHbacPolicyUserMembership_mutiple(t *testing.T) {
 					resource.TestCheckResourceAttr("data.freeipa_hbac_policy.hbacpolicy-1", "member_group.#", "1"),
 					resource.TestCheckResourceAttr("data.freeipa_hbac_policy.hbacpolicy-1", "member_group.0", "testacc-group-0"),
 				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAUser_resource(testMemberUser) + testAccFreeIPAGroup_resource(testGroup) + testAccFreeIPAHbacPolicy_resource(testHbacPolicy) + testAccFreeIPAHbacPolicyUserMembership_resource(testHbacUsersMembership) + testAccFreeIPAHbacPolicyUserMembership_resource(testHbacUserGrpsMembership) + testAccFreeIPAHbacPolicy_datasource(testHbacDS),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccFreeIPAHbacPolicyUserMembership_mutiple_CaseInsensitive(t *testing.T) {
+	testGroup := map[string]string{
+		"index":       "0",
+		"name":        "\"TestACC-Group-0\"",
+		"description": "\"User group test 0\"",
+	}
+	testMemberUser := map[string]string{
+		"index":     "0",
+		"login":     "\"TestACC-User-0\"",
+		"firstname": "\"Test\"",
+		"lastname":  "\"User0\"",
+	}
+	testHbacPolicy := map[string]string{
+		"index":       "1",
+		"name":        "\"TestACC-HBAC-Policy\"",
+		"description": "\"A hbac policy for acceptance tests\"",
+	}
+	testHbacUsersMembership := map[string]string{
+		"index":      "1",
+		"name":       "freeipa_hbac_policy.hbacpolicy-1.name",
+		"users":      "[freeipa_user.user-0.name]",
+		"identifier": "\"users-1\"",
+	}
+	testHbacUserGrpsMembership := map[string]string{
+		"index":      "2",
+		"name":       "freeipa_hbac_policy.hbacpolicy-1.name",
+		"groups":     "[freeipa_group.group-0.name]",
+		"identifier": "\"groups-2\"",
+	}
+	testHbacDS := map[string]string{
+		"index": "1",
+		"name":  "freeipa_hbac_policy.hbacpolicy-1.name",
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAUser_resource(testMemberUser) + testAccFreeIPAGroup_resource(testGroup) + testAccFreeIPAHbacPolicy_resource(testHbacPolicy) + testAccFreeIPAHbacPolicyUserMembership_resource(testHbacUsersMembership) + testAccFreeIPAHbacPolicyUserMembership_resource(testHbacUserGrpsMembership),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("freeipa_hbac_policy.hbacpolicy-1", "name", "TestACC-HBAC-Policy"),
+					resource.TestCheckResourceAttr("freeipa_hbac_policy.hbacpolicy-1", "description", "A hbac policy for acceptance tests"),
+					resource.TestCheckResourceAttr("freeipa_hbac_policy_user_membership.hbac-user-membership-1", "name", "TestACC-HBAC-Policy"),
+					resource.TestCheckResourceAttr("freeipa_hbac_policy_user_membership.hbac-user-membership-1", "users.#", "1"),
+					resource.TestCheckResourceAttr("freeipa_hbac_policy_user_membership.hbac-user-membership-1", "users.0", "TestACC-User-0"),
+					resource.TestCheckResourceAttr("freeipa_hbac_policy_user_membership.hbac-user-membership-2", "name", "TestACC-HBAC-Policy"),
+					resource.TestCheckResourceAttr("freeipa_hbac_policy_user_membership.hbac-user-membership-2", "groups.#", "1"),
+					resource.TestCheckResourceAttr("freeipa_hbac_policy_user_membership.hbac-user-membership-2", "groups.0", "TestACC-Group-0"),
+				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAUser_resource(testMemberUser) + testAccFreeIPAGroup_resource(testGroup) + testAccFreeIPAHbacPolicy_resource(testHbacPolicy) + testAccFreeIPAHbacPolicyUserMembership_resource(testHbacUsersMembership) + testAccFreeIPAHbacPolicyUserMembership_resource(testHbacUserGrpsMembership) + testAccFreeIPAHbacPolicy_datasource(testHbacDS),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.freeipa_hbac_policy.hbacpolicy-1", "name", "TestACC-HBAC-Policy"),
+					resource.TestCheckResourceAttr("data.freeipa_hbac_policy.hbacpolicy-1", "description", "A hbac policy for acceptance tests"),
+					resource.TestCheckResourceAttr("data.freeipa_hbac_policy.hbacpolicy-1", "member_user.#", "1"),
+					resource.TestCheckResourceAttr("data.freeipa_hbac_policy.hbacpolicy-1", "member_user.0", "testacc-user-0"),
+					resource.TestCheckResourceAttr("data.freeipa_hbac_policy.hbacpolicy-1", "member_group.#", "1"),
+					resource.TestCheckResourceAttr("data.freeipa_hbac_policy.hbacpolicy-1", "member_group.0", "testacc-group-0"),
+				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAUser_resource(testMemberUser) + testAccFreeIPAGroup_resource(testGroup) + testAccFreeIPAHbacPolicy_resource(testHbacPolicy) + testAccFreeIPAHbacPolicyUserMembership_resource(testHbacUsersMembership) + testAccFreeIPAHbacPolicyUserMembership_resource(testHbacUserGrpsMembership) + testAccFreeIPAHbacPolicy_datasource(testHbacDS),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 		},
 	})

--- a/freeipa/host_data_source.go
+++ b/freeipa/host_data_source.go
@@ -69,7 +69,7 @@ func (r *HostDataSource) Schema(ctx context.Context, req datasource.SchemaReques
 				Computed:            true,
 			},
 			"name": schema.StringAttribute{
-				MarkdownDescription: "Host name",
+				MarkdownDescription: "Host fully qualified name\n\n	- May contain only letters, numbers, '-'.\n	- DNS label may not start or end with '-'",
 				Required:            true,
 			},
 			"description": schema.StringAttribute{

--- a/freeipa/host_hostgroup_membership_resource.go
+++ b/freeipa/host_hostgroup_membership_resource.go
@@ -262,11 +262,9 @@ func (r *HostGroupMembership) Read(ctx context.Context, req resource.ReadRequest
 
 	switch typeId {
 	case "hg":
-		v := []string{userId}
 		if res.Result.MemberHostgroup != nil {
-			hostgroups := *res.Result.MemberHostgroup
-			if slices.Contains(hostgroups, v[0]) {
-				data.HostGroup = types.StringValue(v[0])
+			if isStringListContainsCaseInsensistive(res.Result.MemberHostgroup, &userId) {
+				data.HostGroup = types.StringValue(userId)
 			} else {
 				data.HostGroup = types.StringValue("")
 				data.Id = types.StringValue("")
@@ -276,11 +274,9 @@ func (r *HostGroupMembership) Read(ctx context.Context, req resource.ReadRequest
 			return
 		}
 	case "h":
-		v := []string{userId}
 		if res.Result.MemberHost != nil {
-			hosts := *res.Result.MemberHost
-			if slices.Contains(hosts, v[0]) {
-				data.Host = types.StringValue(v[0])
+			if isStringListContainsCaseInsensistive(res.Result.MemberHost, &userId) {
+				data.Host = types.StringValue(userId)
 			} else {
 				data.Host = types.StringValue("")
 				data.Id = types.StringValue("")
@@ -298,7 +294,7 @@ func (r *HostGroupMembership) Read(ctx context.Context, req resource.ReadRequest
 				if err != nil {
 					tflog.Debug(ctx, fmt.Sprintf("[DEBUG] Read freeipa hostgroup member hosts failed with error %s", err))
 				}
-				if slices.Contains(*res.Result.MemberHost, val) {
+				if isStringListContainsCaseInsensistive(res.Result.MemberHost, &val) {
 					tflog.Debug(ctx, fmt.Sprintf("[DEBUG] Read freeipa hostgroup member hosts %s is present in results", val))
 					changedVals = append(changedVals, val)
 				}
@@ -317,7 +313,7 @@ func (r *HostGroupMembership) Read(ctx context.Context, req resource.ReadRequest
 				if err != nil {
 					tflog.Debug(ctx, fmt.Sprintf("[DEBUG] Read freeipa hostgroup member hostgroups failed with error %s", err))
 				}
-				if slices.Contains(*res.Result.MemberHostgroup, val) {
+				if isStringListContainsCaseInsensistive(res.Result.MemberHostgroup, &val) {
 					tflog.Debug(ctx, fmt.Sprintf("[DEBUG] Read freeipa hostgroup member hostgroups %s is present in results", val))
 					changedVals = append(changedVals, val)
 				}

--- a/freeipa/host_hostgroup_membership_test.go
+++ b/freeipa/host_hostgroup_membership_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 func TestAccFreeIPAHostGroupMembership_simple(t *testing.T) {
@@ -45,6 +46,66 @@ func TestAccFreeIPAHostGroupMembership_simple(t *testing.T) {
 					resource.TestCheckResourceAttr("freeipa_host_hostgroup_membership.membership-0", "host", "testacc-host-1.testacc.ipatest.lan"),
 					resource.TestCheckResourceAttr("freeipa_host_hostgroup_membership.membership-1", "hostgroup", "testacc-groupmember"),
 				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPADNSZone_resource(testZone) + testAccFreeIPAHost_resource(testMemberHost) + testAccFreeIPAHostGroup_resource(testHostGroup) + testAccFreeIPAHostGroup_resource(testMemberHostGroup) + testAccFreeIPAHostGroupMembership_resource(testMembershipHost) + testAccFreeIPAHostGroupMembership_resource(testMembershipHostGroup),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccFreeIPAHostGroupMembership_simple_CaseInsensitive(t *testing.T) {
+	testZone := map[string]string{
+		"index":     "0",
+		"zone_name": "\"Testacc.ipatest.lan\"",
+	}
+	testMemberHost := map[string]string{
+		"index":      "0",
+		"name":       "\"TestACC-Host-1.${freeipa_dns_zone.dns-zone-0.zone_name}\"",
+		"ip_address": "\"192.168.10.65\"",
+	}
+	testHostGroup := map[string]string{
+		"index": "0",
+		"name":  "\"TestACC-HostGroup\"",
+	}
+	testMemberHostGroup := map[string]string{
+		"index": "1",
+		"name":  "\"TestACC-GroupMember\"",
+	}
+	testMembershipHost := map[string]string{
+		"index": "0",
+		"name":  "freeipa_hostgroup.hostgroup-0.name",
+		"host":  "freeipa_host.host-0.name",
+	}
+	testMembershipHostGroup := map[string]string{
+		"index":     "1",
+		"name":      "freeipa_hostgroup.hostgroup-0.name",
+		"hostgroup": "freeipa_hostgroup.hostgroup-1.name",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPADNSZone_resource(testZone) + testAccFreeIPAHost_resource(testMemberHost) + testAccFreeIPAHostGroup_resource(testHostGroup) + testAccFreeIPAHostGroup_resource(testMemberHostGroup) + testAccFreeIPAHostGroupMembership_resource(testMembershipHost) + testAccFreeIPAHostGroupMembership_resource(testMembershipHostGroup),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("freeipa_host_hostgroup_membership.membership-0", "host", "TestACC-Host-1.Testacc.ipatest.lan"),
+					resource.TestCheckResourceAttr("freeipa_host_hostgroup_membership.membership-1", "hostgroup", "TestACC-GroupMember"),
+				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPADNSZone_resource(testZone) + testAccFreeIPAHost_resource(testMemberHost) + testAccFreeIPAHostGroup_resource(testHostGroup) + testAccFreeIPAHostGroup_resource(testMemberHostGroup) + testAccFreeIPAHostGroupMembership_resource(testMembershipHost) + testAccFreeIPAHostGroupMembership_resource(testMembershipHostGroup),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 		},
 	})
@@ -93,6 +154,70 @@ func TestAccFreeIPAHostGroupMembership_multiple(t *testing.T) {
 					resource.TestCheckResourceAttr("freeipa_host_hostgroup_membership.membership-1", "hostgroups.#", "1"),
 					resource.TestCheckResourceAttr("freeipa_host_hostgroup_membership.membership-1", "hostgroups.0", "testacc-groupmember"),
 				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPADNSZone_resource(testZone) + testAccFreeIPAHost_resource(testMemberHost) + testAccFreeIPAHostGroup_resource(testHostGroup) + testAccFreeIPAHostGroup_resource(testMemberHostGroup) + testAccFreeIPAHostGroupMembership_resource(testMembershipHost) + testAccFreeIPAHostGroupMembership_resource(testMembershipHostGroup),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccFreeIPAHostGroupMembership_multiple_CaseInsensitive(t *testing.T) {
+	testZone := map[string]string{
+		"index":     "0",
+		"zone_name": "\"TestACC.ipatest.lan\"",
+	}
+	testMemberHost := map[string]string{
+		"index":      "0",
+		"name":       "\"TestACC-Host-1.${freeipa_dns_zone.dns-zone-0.zone_name}\"",
+		"ip_address": "\"192.168.10.65\"",
+	}
+	testHostGroup := map[string]string{
+		"index": "0",
+		"name":  "\"TestACC-HostGroup\"",
+	}
+	testMemberHostGroup := map[string]string{
+		"index": "1",
+		"name":  "\"TestACC-GroupMember\"",
+	}
+	testMembershipHost := map[string]string{
+		"index":      "0",
+		"name":       "freeipa_hostgroup.hostgroup-0.name",
+		"hosts":      "[freeipa_host.host-0.name]",
+		"identifier": "1",
+	}
+	testMembershipHostGroup := map[string]string{
+		"index":      "1",
+		"name":       "freeipa_hostgroup.hostgroup-0.name",
+		"hostgroups": "[freeipa_hostgroup.hostgroup-1.name]",
+		"identifier": "2",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPADNSZone_resource(testZone) + testAccFreeIPAHost_resource(testMemberHost) + testAccFreeIPAHostGroup_resource(testHostGroup) + testAccFreeIPAHostGroup_resource(testMemberHostGroup) + testAccFreeIPAHostGroupMembership_resource(testMembershipHost) + testAccFreeIPAHostGroupMembership_resource(testMembershipHostGroup),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("freeipa_host_hostgroup_membership.membership-0", "hosts.#", "1"),
+					resource.TestCheckResourceAttr("freeipa_host_hostgroup_membership.membership-0", "hosts.0", "TestACC-Host-1.TestACC.ipatest.lan"),
+					resource.TestCheckResourceAttr("freeipa_host_hostgroup_membership.membership-1", "hostgroups.#", "1"),
+					resource.TestCheckResourceAttr("freeipa_host_hostgroup_membership.membership-1", "hostgroups.0", "TestACC-GroupMember"),
+				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPADNSZone_resource(testZone) + testAccFreeIPAHost_resource(testMemberHost) + testAccFreeIPAHostGroup_resource(testHostGroup) + testAccFreeIPAHostGroup_resource(testMemberHostGroup) + testAccFreeIPAHostGroupMembership_resource(testMembershipHost) + testAccFreeIPAHostGroupMembership_resource(testMembershipHostGroup),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 		},
 	})

--- a/freeipa/host_resource.go
+++ b/freeipa/host_resource.go
@@ -305,7 +305,7 @@ func (r *HostResource) Create(ctx context.Context, req resource.CreateRequest, r
 		data.GeneratedPassword = types.StringValue("")
 	}
 
-	data.Id = data.Name
+	data.Id = types.StringValue(res.Result.Fqdn)
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/freeipa/host_resource.go
+++ b/freeipa/host_resource.go
@@ -81,7 +81,7 @@ func (r *HostResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 				},
 			},
 			"name": schema.StringAttribute{
-				MarkdownDescription: "Host name",
+				MarkdownDescription: "Host fully qualified name\n\n	- May contain only letters, numbers, '-'.\n	- DNS label may not start or end with '-'",
 				Required:            true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),

--- a/freeipa/hostgroup_data_source.go
+++ b/freeipa/hostgroup_data_source.go
@@ -174,7 +174,6 @@ func (r *HostGroupDataSource) Read(ctx context.Context, req datasource.ReadReque
 		return
 	}
 
-	data.Name = types.StringValue(res.Result.Cn)
 	tflog.Debug(ctx, fmt.Sprintf("[DEBUG] Read freeipa hostgroup Cn %s", data.Name.ValueString()))
 	if res.Result.Description != nil {
 		data.Description = types.StringValue(*res.Result.Description)
@@ -260,7 +259,7 @@ func (r *HostGroupDataSource) Read(ctx context.Context, req datasource.ReadReque
 		}
 	}
 
-	data.Id = types.StringValue(data.Name.ValueString())
+	data.Id = types.StringValue(res.Result.Cn)
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/freeipa/hostgroup_resource .go
+++ b/freeipa/hostgroup_resource .go
@@ -114,13 +114,12 @@ func (r *HostGroupResource) Create(ctx context.Context, req resource.CreateReque
 	}
 	tflog.Trace(ctx, "created a host group resource")
 
-	data.Id = types.StringValue(data.Name.ValueString())
-
-	_, err := r.client.HostgroupAdd(&args, &optArgs)
+	res, err := r.client.HostgroupAdd(&args, &optArgs)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Error creating freeipa host group: %s", err))
 	}
 
+	data.Id = types.StringValue(res.Result.Cn)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -145,7 +144,7 @@ func (r *HostGroupResource) Read(ctx context.Context, req resource.ReadRequest, 
 	}
 
 	args := ipa.HostgroupShowArgs{
-		Cn: data.Id.ValueString(),
+		Cn: data.Name.ValueString(),
 	}
 
 	tflog.Debug(ctx, fmt.Sprintf("[DEBUG] Read freeipa hostgroup %s", data.Id.ValueString()))
@@ -167,7 +166,7 @@ func (r *HostGroupResource) Read(ctx context.Context, req resource.ReadRequest, 
 		return
 	}
 
-	data.Name = types.StringValue(res.Result.Cn)
+	//data.Name = types.StringValue(res.Result.Cn)
 	tflog.Debug(ctx, fmt.Sprintf("[DEBUG] Read freeipa hostgroup Cn %s", data.Name.ValueString()))
 	if res.Result.Description != nil && !data.Description.IsNull() {
 		data.Description = types.StringValue(*res.Result.Description)

--- a/freeipa/hostgroup_test.go
+++ b/freeipa/hostgroup_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 func TestAccFreeIPAHostgroup_posix(t *testing.T) {
@@ -38,6 +39,57 @@ func TestAccFreeIPAHostgroup_posix(t *testing.T) {
 					resource.TestCheckResourceAttr("freeipa_hostgroup.hostgroup-1", "description", "Modified description"),
 					resource.TestCheckResourceAttr("data.freeipa_hostgroup.hostgroup-1", "description", "Modified description"),
 				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAHostGroup_resource(testHostgroupModified) + testAccFreeIPAHostGroup_datasource(testHostgroupDS),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccFreeIPAHostgroup_posix_CaseInsensitive(t *testing.T) {
+	testHostgroup := map[string]string{
+		"index":       "1",
+		"name":        "\"TestACC-Group-1\"",
+		"description": "\"Test hostgroup 1\"",
+	}
+	testHostgroupDS := map[string]string{
+		"index": "1",
+		"name":  "freeipa_hostgroup.hostgroup-1.name",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAHostGroup_resource(testHostgroup),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("freeipa_hostgroup.hostgroup-1", "id", "testacc-group-1"),
+					resource.TestCheckResourceAttr("freeipa_hostgroup.hostgroup-1", "name", "TestACC-Group-1"),
+					resource.TestCheckResourceAttr("freeipa_hostgroup.hostgroup-1", "description", "Test hostgroup 1"),
+				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAHostGroup_resource(testHostgroup) + testAccFreeIPAHostGroup_datasource(testHostgroupDS),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("freeipa_hostgroup.hostgroup-1", "description", "Test hostgroup 1"),
+					resource.TestCheckResourceAttr("data.freeipa_hostgroup.hostgroup-1", "name", "TestACC-Group-1"),
+					resource.TestCheckResourceAttr("data.freeipa_hostgroup.hostgroup-1", "description", "Test hostgroup 1"),
+				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAHostGroup_resource(testHostgroup) + testAccFreeIPAHostGroup_datasource(testHostgroupDS),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 		},
 	})

--- a/freeipa/sudo_cmd_resource.go
+++ b/freeipa/sudo_cmd_resource.go
@@ -60,7 +60,7 @@ func (r *SudoCmdResource) Schema(ctx context.Context, req resource.SchemaRequest
 				},
 			},
 			"name": schema.StringAttribute{
-				MarkdownDescription: "Absolute path of the sudo command",
+				MarkdownDescription: "Absolute path of the sudo command (case sensitive)",
 				Required:            true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),

--- a/freeipa/sudo_cmd_test.go
+++ b/freeipa/sudo_cmd_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 func TestAccFreeIPASudoCmd_simple(t *testing.T) {
@@ -23,6 +24,44 @@ func TestAccFreeIPASudoCmd_simple(t *testing.T) {
 					resource.TestCheckResourceAttr("freeipa_sudo_cmd.sudocmd-1", "name", "/usr/bin/testacc-bash"),
 					resource.TestCheckResourceAttr("freeipa_sudo_cmd.sudocmd-1", "description", "The bash shell"),
 				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPASudoCmd_resource(testSudoCmd),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccFreeIPASudoCmd_simple_CaseSensitive(t *testing.T) {
+	testSudoCmd := map[string]string{
+		"index":       "1",
+		"name":        "\"/usr/bin/TestACC-Bash\"",
+		"description": "\"The bash shell\"",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPASudoCmd_resource(testSudoCmd),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("freeipa_sudo_cmd.sudocmd-1", "name", "/usr/bin/TestACC-Bash"),
+					resource.TestCheckResourceAttr("freeipa_sudo_cmd.sudocmd-1", "description", "The bash shell"),
+				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPASudoCmd_resource(testSudoCmd),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 		},
 	})

--- a/freeipa/sudo_cmdgroup_data_source.go
+++ b/freeipa/sudo_cmdgroup_data_source.go
@@ -122,7 +122,7 @@ func (r *SudoCmdGroupDataSource) Read(ctx context.Context, req datasource.ReadRe
 	if res.Result.MemberSudocmd != nil {
 		data.MemberSudocmd, _ = types.ListValueFrom(ctx, types.StringType, res.Result.MemberSudocmd)
 	}
-	data.Id = data.Name
+	data.Id = types.StringValue(res.Result.Cn)
 	tflog.Debug(ctx, fmt.Sprintf("[DEBUG] Read freeipa sudo command group %s", res.Result.Cn))
 
 	// Save updated data into Terraform state

--- a/freeipa/sudo_cmdgroup_membership_test.go
+++ b/freeipa/sudo_cmdgroup_membership_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 func TestAccFreeIPASudoCmdGrpMembership_simple(t *testing.T) {
@@ -37,6 +38,58 @@ func TestAccFreeIPASudoCmdGrpMembership_simple(t *testing.T) {
 					resource.TestCheckResourceAttr("freeipa_sudo_cmdgroup_membership.sudocmdgroup-membership-1", "name", "testacc-terminals"),
 					resource.TestCheckResourceAttr("freeipa_sudo_cmdgroup_membership.sudocmdgroup-membership-1", "sudocmd", "/usr/bin/testacc-bash"),
 				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPASudoCmd_resource(testSudoCmd1) + testAccFreeIPASudoCmdGrp_resource(testSudoCmdGrp) + testAccFreeIPASudoCmdGrpMembership_resource(testSudoCmdGrpMembership),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccFreeIPASudoCmdGrpMembership_simple_CaseInsensitive(t *testing.T) {
+	testSudoCmd1 := map[string]string{
+		"index":       "1",
+		"name":        "\"/usr/bin/TestACC-Bash\"",
+		"description": "\"The bash shell\"",
+	}
+	testSudoCmdGrp := map[string]string{
+		"index":       "1",
+		"name":        "\"TestACC-Terminals\"",
+		"description": "\"A set of terminals\"",
+	}
+	testSudoCmdGrpMembership := map[string]string{
+		"index":   "1",
+		"name":    "freeipa_sudo_cmdgroup.sudocmdgroup-1.name",
+		"sudocmd": "freeipa_sudo_cmd.sudocmd-1.name",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPASudoCmd_resource(testSudoCmd1) + testAccFreeIPASudoCmdGrp_resource(testSudoCmdGrp) + testAccFreeIPASudoCmdGrpMembership_resource(testSudoCmdGrpMembership),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("freeipa_sudo_cmd.sudocmd-1", "name", "/usr/bin/TestACC-Bash"),
+					resource.TestCheckResourceAttr("freeipa_sudo_cmd.sudocmd-1", "description", "The bash shell"),
+					resource.TestCheckResourceAttr("freeipa_sudo_cmdgroup.sudocmdgroup-1", "name", "TestACC-Terminals"),
+					resource.TestCheckResourceAttr("freeipa_sudo_cmdgroup.sudocmdgroup-1", "description", "A set of terminals"),
+					resource.TestCheckResourceAttr("freeipa_sudo_cmdgroup_membership.sudocmdgroup-membership-1", "name", "TestACC-Terminals"),
+					resource.TestCheckResourceAttr("freeipa_sudo_cmdgroup_membership.sudocmdgroup-membership-1", "sudocmd", "/usr/bin/TestACC-Bash"),
+				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPASudoCmd_resource(testSudoCmd1) + testAccFreeIPASudoCmdGrp_resource(testSudoCmdGrp) + testAccFreeIPASudoCmdGrpMembership_resource(testSudoCmdGrpMembership),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 		},
 	})
@@ -106,6 +159,92 @@ func TestAccFreeIPASudoCmdGrpMembership_mutiple(t *testing.T) {
 					resource.TestCheckResourceAttr("data.freeipa_sudo_cmdgroup.sudocmdgroup-1", "member_sudocmd.1", "/usr/bin/testacc-fish"),
 					resource.TestCheckResourceAttr("data.freeipa_sudo_cmdgroup.sudocmdgroup-1", "member_sudocmd.2", "/usr/bin/testacc-zsh"),
 				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPASudoCmd_resource(testSudoCmd1) + testAccFreeIPASudoCmd_resource(testSudoCmd2) + testAccFreeIPASudoCmd_resource(testSudoCmd3) + testAccFreeIPASudoCmdGrp_resource(testSudoCmdGrp) + testAccFreeIPASudoCmdGrpMembership_resource(testSudoCmdGrpMembership) + testAccFreeIPASudoCmdGroup_datasource(testSudoCmdGrpDS),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccFreeIPASudoCmdGrpMembership_mutiple_CaseInsensitive(t *testing.T) {
+	testSudoCmd1 := map[string]string{
+		"index":       "1",
+		"name":        "\"/usr/bin/TestACC-Bash\"",
+		"description": "\"The bash shell\"",
+	}
+	testSudoCmd2 := map[string]string{
+		"index":       "2",
+		"name":        "\"/usr/bin/testacc-fish\"",
+		"description": "\"The fish shell\"",
+	}
+	testSudoCmd3 := map[string]string{
+		"index":       "3",
+		"name":        "\"/usr/bin/testacc-zsh\"",
+		"description": "\"The zsh shell\"",
+	}
+	testSudoCmdGrp := map[string]string{
+		"index":       "1",
+		"name":        "\"TestACC-Terminals\"",
+		"description": "\"A set of terminals\"",
+	}
+	testSudoCmdGrpMembership := map[string]string{
+		"index":       "1",
+		"name":        "freeipa_sudo_cmdgroup.sudocmdgroup-1.name",
+		"sudocmds":    "[freeipa_sudo_cmd.sudocmd-1.name,freeipa_sudo_cmd.sudocmd-2.name,freeipa_sudo_cmd.sudocmd-3.name]",
+		"indentifier": "multiplecmds",
+	}
+	testSudoCmdGrpDS := map[string]string{
+		"index": "1",
+		"name":  "freeipa_sudo_cmdgroup.sudocmdgroup-1.name",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPASudoCmd_resource(testSudoCmd1) + testAccFreeIPASudoCmd_resource(testSudoCmd2) + testAccFreeIPASudoCmd_resource(testSudoCmd3) + testAccFreeIPASudoCmdGrp_resource(testSudoCmdGrp) + testAccFreeIPASudoCmdGrpMembership_resource(testSudoCmdGrpMembership),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("freeipa_sudo_cmd.sudocmd-1", "name", "/usr/bin/TestACC-Bash"),
+					resource.TestCheckResourceAttr("freeipa_sudo_cmd.sudocmd-1", "description", "The bash shell"),
+					resource.TestCheckResourceAttr("freeipa_sudo_cmd.sudocmd-2", "name", "/usr/bin/testacc-fish"),
+					resource.TestCheckResourceAttr("freeipa_sudo_cmd.sudocmd-2", "description", "The fish shell"),
+					resource.TestCheckResourceAttr("freeipa_sudo_cmd.sudocmd-3", "name", "/usr/bin/testacc-zsh"),
+					resource.TestCheckResourceAttr("freeipa_sudo_cmd.sudocmd-3", "description", "The zsh shell"),
+					resource.TestCheckResourceAttr("freeipa_sudo_cmdgroup.sudocmdgroup-1", "name", "TestACC-Terminals"),
+					resource.TestCheckResourceAttr("freeipa_sudo_cmdgroup.sudocmdgroup-1", "description", "A set of terminals"),
+					resource.TestCheckResourceAttr("freeipa_sudo_cmdgroup_membership.sudocmdgroup-membership-1", "name", "TestACC-Terminals"),
+					resource.TestCheckResourceAttr("freeipa_sudo_cmdgroup_membership.sudocmdgroup-membership-1", "sudocmds.#", "3"),
+					resource.TestCheckResourceAttr("freeipa_sudo_cmdgroup_membership.sudocmdgroup-membership-1", "sudocmds.0", "/usr/bin/TestACC-Bash"),
+					resource.TestCheckResourceAttr("freeipa_sudo_cmdgroup_membership.sudocmdgroup-membership-1", "sudocmds.1", "/usr/bin/testacc-fish"),
+					resource.TestCheckResourceAttr("freeipa_sudo_cmdgroup_membership.sudocmdgroup-membership-1", "sudocmds.2", "/usr/bin/testacc-zsh"),
+				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPASudoCmd_resource(testSudoCmd1) + testAccFreeIPASudoCmd_resource(testSudoCmd2) + testAccFreeIPASudoCmd_resource(testSudoCmd3) + testAccFreeIPASudoCmdGrp_resource(testSudoCmdGrp) + testAccFreeIPASudoCmdGrpMembership_resource(testSudoCmdGrpMembership) + testAccFreeIPASudoCmdGroup_datasource(testSudoCmdGrpDS),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.freeipa_sudo_cmdgroup.sudocmdgroup-1", "id", "testacc-terminals"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_cmdgroup.sudocmdgroup-1", "name", "TestACC-Terminals"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_cmdgroup.sudocmdgroup-1", "description", "A set of terminals"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_cmdgroup.sudocmdgroup-1", "member_sudocmd.#", "3"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_cmdgroup.sudocmdgroup-1", "member_sudocmd.0", "/usr/bin/TestACC-Bash"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_cmdgroup.sudocmdgroup-1", "member_sudocmd.1", "/usr/bin/testacc-fish"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_cmdgroup.sudocmdgroup-1", "member_sudocmd.2", "/usr/bin/testacc-zsh"),
+				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPASudoCmd_resource(testSudoCmd1) + testAccFreeIPASudoCmd_resource(testSudoCmd2) + testAccFreeIPASudoCmd_resource(testSudoCmd3) + testAccFreeIPASudoCmdGrp_resource(testSudoCmdGrp) + testAccFreeIPASudoCmdGrpMembership_resource(testSudoCmdGrpMembership) + testAccFreeIPASudoCmdGroup_datasource(testSudoCmdGrpDS),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 		},
 	})

--- a/freeipa/sudo_cmdgroup_test.go
+++ b/freeipa/sudo_cmdgroup_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 func TestAccFreeIPASudoCmdGrp_simple(t *testing.T) {
@@ -23,6 +24,44 @@ func TestAccFreeIPASudoCmdGrp_simple(t *testing.T) {
 					resource.TestCheckResourceAttr("freeipa_sudo_cmdgroup.sudocmdgroup-1", "name", "testacc-command-group-1"),
 					resource.TestCheckResourceAttr("freeipa_sudo_cmdgroup.sudocmdgroup-1", "description", "A set of commands"),
 				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPASudoCmdGrp_resource(testSudoCmdGrp),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccFreeIPASudoCmdGrp_CaseInsensitive(t *testing.T) {
+	testSudoCmdGrp := map[string]string{
+		"index":       "1",
+		"name":        "\"Testacc Command Group 1\"",
+		"description": "\"A set of commands\"",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPASudoCmdGrp_resource(testSudoCmdGrp),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("freeipa_sudo_cmdgroup.sudocmdgroup-1", "name", "Testacc Command Group 1"),
+					resource.TestCheckResourceAttr("freeipa_sudo_cmdgroup.sudocmdgroup-1", "description", "A set of commands"),
+				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPASudoCmdGrp_resource(testSudoCmdGrp),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 		},
 	})

--- a/freeipa/sudo_rule_allowcmd_membership_resource.go
+++ b/freeipa/sudo_rule_allowcmd_membership_resource.go
@@ -267,7 +267,7 @@ func (r *SudoRuleAllowCmdMembershipResource) Read(ctx context.Context, req resou
 			return
 		}
 	case "sracg":
-		if res.Result.MemberallowcmdSudocmdgroup == nil || !slices.Contains(*res.Result.MemberallowcmdSudocmdgroup, cmdId) {
+		if res.Result.MemberallowcmdSudocmdgroup == nil || !isStringListContainsCaseInsensistive(res.Result.MemberallowcmdSudocmdgroup, &cmdId) {
 			tflog.Debug(ctx, "[DEBUG] Sudo rule allowed command groupmembership does not exist")
 			resp.State.RemoveResource(ctx)
 			return
@@ -298,7 +298,7 @@ func (r *SudoRuleAllowCmdMembershipResource) Read(ctx context.Context, req resou
 				if err != nil {
 					tflog.Debug(ctx, fmt.Sprintf("[DEBUG] Read freeipa sudo command member commands failed with error %s", err))
 				}
-				if res.Result.MemberallowcmdSudocmdgroup != nil && slices.Contains(*res.Result.MemberallowcmdSudocmdgroup, val) {
+				if res.Result.MemberallowcmdSudocmdgroup != nil && isStringListContainsCaseInsensistive(res.Result.MemberallowcmdSudocmdgroup, &val) {
 					tflog.Debug(ctx, fmt.Sprintf("[DEBUG] Read freeipa sudo command member commands %s is present in results", val))
 					changedVals = append(changedVals, val)
 				}

--- a/freeipa/sudo_rule_allowcmd_membership_test.go
+++ b/freeipa/sudo_rule_allowcmd_membership_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 func TestAccFreeIPASudoRuleAllowCmdMembership_simple(t *testing.T) {
@@ -73,6 +74,94 @@ func TestAccFreeIPASudoRuleAllowCmdMembership_simple(t *testing.T) {
 					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "member_allow_sudo_cmdgroup.#", "1"),
 					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "member_allow_sudo_cmdgroup.0", "testacc-terminals"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccFreeIPASudoRuleAllowCmdMembership_CaseInsensitive(t *testing.T) {
+	testSudoCmd1 := map[string]string{
+		"index":       "1",
+		"name":        "\"/usr/bin/testacc-bash\"",
+		"description": "\"The bash shell\"",
+	}
+	testSudoCmdGrp := map[string]string{
+		"index":       "1",
+		"name":        "\"Testacc Terminals\"",
+		"description": "\"A set of terminals\"",
+	}
+	testSudoCmdGrpMembership := map[string]string{
+		"index":   "1",
+		"name":    "freeipa_sudo_cmdgroup.sudocmdgroup-1.name",
+		"sudocmd": "freeipa_sudo_cmd.sudocmd-1.name",
+	}
+	testSudoRule := map[string]string{
+		"index":       "1",
+		"name":        "\"testacc-sudorule\"",
+		"description": "\"A sudo rule for acceptance tests\"",
+	}
+	testSudoAllowCmdMembership := map[string]string{
+		"index":   "1",
+		"name":    "freeipa_sudo_rule.sudorule-1.name",
+		"sudocmd": "freeipa_sudo_cmd.sudocmd-1.name",
+	}
+	testSudoAllowCmdGrpMembership := map[string]string{
+		"index":         "2",
+		"name":          "freeipa_sudo_rule.sudorule-1.name",
+		"sudocmd_group": "freeipa_sudo_cmdgroup.sudocmdgroup-1.name",
+	}
+	testSudoDS := map[string]string{
+		"index": "1",
+		"name":  "freeipa_sudo_rule.sudorule-1.name",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPASudoCmd_resource(testSudoCmd1) + testAccFreeIPASudoCmdGrp_resource(testSudoCmdGrp) + testAccFreeIPASudoCmdGrpMembership_resource(testSudoCmdGrpMembership) + testAccFreeIPASudoRule_resource(testSudoRule) + testAccFreeIPASudoAllowCmdMembership_resource(testSudoAllowCmdMembership) + testAccFreeIPASudoAllowCmdMembership_resource(testSudoAllowCmdGrpMembership),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("freeipa_sudo_cmd.sudocmd-1", "name", "/usr/bin/testacc-bash"),
+					resource.TestCheckResourceAttr("freeipa_sudo_cmd.sudocmd-1", "description", "The bash shell"),
+					resource.TestCheckResourceAttr("freeipa_sudo_cmdgroup.sudocmdgroup-1", "name", "Testacc Terminals"),
+					resource.TestCheckResourceAttr("freeipa_sudo_cmdgroup.sudocmdgroup-1", "description", "A set of terminals"),
+					resource.TestCheckResourceAttr("freeipa_sudo_cmdgroup_membership.sudocmdgroup-membership-1", "name", "Testacc Terminals"),
+					resource.TestCheckResourceAttr("freeipa_sudo_cmdgroup_membership.sudocmdgroup-membership-1", "sudocmd", "/usr/bin/testacc-bash"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule.sudorule-1", "name", "testacc-sudorule"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule.sudorule-1", "description", "A sudo rule for acceptance tests"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule_allowcmd_membership.sudo-allow-membership-1", "name", "testacc-sudorule"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule_allowcmd_membership.sudo-allow-membership-1", "sudocmd", "/usr/bin/testacc-bash"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule_allowcmd_membership.sudo-allow-membership-2", "name", "testacc-sudorule"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule_allowcmd_membership.sudo-allow-membership-2", "sudocmd_group", "Testacc Terminals"),
+				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPASudoCmd_resource(testSudoCmd1) + testAccFreeIPASudoCmdGrp_resource(testSudoCmdGrp) + testAccFreeIPASudoCmdGrpMembership_resource(testSudoCmdGrpMembership) + testAccFreeIPASudoRule_resource(testSudoRule) + testAccFreeIPASudoAllowCmdMembership_resource(testSudoAllowCmdMembership) + testAccFreeIPASudoAllowCmdMembership_resource(testSudoAllowCmdGrpMembership),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPASudoCmd_resource(testSudoCmd1) + testAccFreeIPASudoCmdGrp_resource(testSudoCmdGrp) + testAccFreeIPASudoCmdGrpMembership_resource(testSudoCmdGrpMembership) + testAccFreeIPASudoRule_resource(testSudoRule) + testAccFreeIPASudoAllowCmdMembership_resource(testSudoAllowCmdMembership) + testAccFreeIPASudoAllowCmdMembership_resource(testSudoAllowCmdGrpMembership) + testAccFreeIPASudoRule_datasource(testSudoDS),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "name", "testacc-sudorule"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "description", "A sudo rule for acceptance tests"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "member_allow_sudo_cmd.#", "1"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "member_allow_sudo_cmd.0", "/usr/bin/testacc-bash"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "member_allow_sudo_cmdgroup.#", "1"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "member_allow_sudo_cmdgroup.0", "testacc terminals"),
+				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPASudoCmd_resource(testSudoCmd1) + testAccFreeIPASudoCmdGrp_resource(testSudoCmdGrp) + testAccFreeIPASudoCmdGrpMembership_resource(testSudoCmdGrpMembership) + testAccFreeIPASudoRule_resource(testSudoRule) + testAccFreeIPASudoAllowCmdMembership_resource(testSudoAllowCmdMembership) + testAccFreeIPASudoAllowCmdMembership_resource(testSudoAllowCmdGrpMembership) + testAccFreeIPASudoRule_datasource(testSudoDS),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 		},
 	})
@@ -175,6 +264,134 @@ func TestAccFreeIPASudoRuleAllowCmdMembership_mutiple(t *testing.T) {
 					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "member_allow_sudo_cmdgroup.#", "1"),
 					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "member_allow_sudo_cmdgroup.0", "testacc-terminals"),
 				),
+			},
+		},
+	})
+}
+func TestAccFreeIPASudoRuleAllowCmdMembership_multiple_CaseInsensitive(t *testing.T) {
+	testSudoCmd1 := map[string]string{
+		"index":       "1",
+		"name":        "\"/usr/bin/Testacc-Bash\"",
+		"description": "\"The bash shell\"",
+	}
+	testSudoCmd2 := map[string]string{
+		"index":       "2",
+		"name":        "\"/usr/bin/Testacc-Fish\"",
+		"description": "\"The fish shell\"",
+	}
+	testSudoCmd3 := map[string]string{
+		"index":       "3",
+		"name":        "\"/usr/bin/Testacc-Zsh\"",
+		"description": "\"The zsh shell\"",
+	}
+	testSudoCmdGrp := map[string]string{
+		"index":       "1",
+		"name":        "\"Testacc Terminals\"",
+		"description": "\"A set of terminals\"",
+	}
+	testSudoCmdGrp2 := map[string]string{
+		"index":       "2",
+		"name":        "\"Testacc Services\"",
+		"description": "\"A set of services\"",
+	}
+	testSudoCmdGrpMembership := map[string]string{
+		"index":       "1",
+		"name":        "freeipa_sudo_cmdgroup.sudocmdgroup-1.name",
+		"sudocmds":    "[freeipa_sudo_cmd.sudocmd-1.name,freeipa_sudo_cmd.sudocmd-2.name,freeipa_sudo_cmd.sudocmd-3.name]",
+		"indentifier": "multiplecmds",
+	}
+	testSudoRule := map[string]string{
+		"index":       "1",
+		"name":        "\"testacc-sudorule\"",
+		"description": "\"A sudo rule for acceptance tests\"",
+	}
+	testSudoAllowCmdMembership := map[string]string{
+		"index":      "1",
+		"name":       "freeipa_sudo_rule.sudorule-1.name",
+		"sudocmds":   "[freeipa_sudo_cmd.sudocmd-1.name, freeipa_sudo_cmd.sudocmd-2.name, freeipa_sudo_cmd.sudocmd-3.name]",
+		"identifier": "\"testacc-allowcmds\"",
+	}
+	testSudoAllowCmdGrpMembership := map[string]string{
+		"index":          "2",
+		"name":           "freeipa_sudo_rule.sudorule-1.name",
+		"sudocmd_groups": "[freeipa_sudo_cmdgroup.sudocmdgroup-1.name, freeipa_sudo_cmdgroup.sudocmdgroup-2.name]",
+		"identifier":     "\"testacc-allowcmdgroups\"",
+	}
+	testSudoCmdGrpDS := map[string]string{
+		"index": "1",
+		"name":  "freeipa_sudo_cmdgroup.sudocmdgroup-1.name",
+	}
+	testSudoDS := map[string]string{
+		"index": "1",
+		"name":  "freeipa_sudo_rule.sudorule-1.name",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPASudoCmd_resource(testSudoCmd1) + testAccFreeIPASudoCmd_resource(testSudoCmd2) + testAccFreeIPASudoCmd_resource(testSudoCmd3) + testAccFreeIPASudoCmdGrp_resource(testSudoCmdGrp) + testAccFreeIPASudoCmdGrp_resource(testSudoCmdGrp2) + testAccFreeIPASudoCmdGrpMembership_resource(testSudoCmdGrpMembership) + testAccFreeIPASudoRule_resource(testSudoRule) + testAccFreeIPASudoAllowCmdMembership_resource(testSudoAllowCmdMembership) + testAccFreeIPASudoAllowCmdMembership_resource(testSudoAllowCmdGrpMembership),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("freeipa_sudo_cmd.sudocmd-1", "name", "/usr/bin/Testacc-Bash"),
+					resource.TestCheckResourceAttr("freeipa_sudo_cmd.sudocmd-1", "description", "The bash shell"),
+					resource.TestCheckResourceAttr("freeipa_sudo_cmd.sudocmd-2", "name", "/usr/bin/Testacc-Fish"),
+					resource.TestCheckResourceAttr("freeipa_sudo_cmd.sudocmd-2", "description", "The fish shell"),
+					resource.TestCheckResourceAttr("freeipa_sudo_cmd.sudocmd-3", "name", "/usr/bin/Testacc-Zsh"),
+					resource.TestCheckResourceAttr("freeipa_sudo_cmd.sudocmd-3", "description", "The zsh shell"),
+					resource.TestCheckResourceAttr("freeipa_sudo_cmdgroup.sudocmdgroup-1", "name", "Testacc Terminals"),
+					resource.TestCheckResourceAttr("freeipa_sudo_cmdgroup.sudocmdgroup-1", "description", "A set of terminals"),
+					resource.TestCheckResourceAttr("freeipa_sudo_cmdgroup_membership.sudocmdgroup-membership-1", "name", "Testacc Terminals"),
+					resource.TestCheckResourceAttr("freeipa_sudo_cmdgroup_membership.sudocmdgroup-membership-1", "sudocmds.#", "3"),
+					resource.TestCheckResourceAttr("freeipa_sudo_cmdgroup_membership.sudocmdgroup-membership-1", "sudocmds.0", "/usr/bin/Testacc-Bash"),
+					resource.TestCheckResourceAttr("freeipa_sudo_cmdgroup_membership.sudocmdgroup-membership-1", "sudocmds.1", "/usr/bin/Testacc-Fish"),
+					resource.TestCheckResourceAttr("freeipa_sudo_cmdgroup_membership.sudocmdgroup-membership-1", "sudocmds.2", "/usr/bin/Testacc-Zsh"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule_allowcmd_membership.sudo-allow-membership-1", "name", "testacc-sudorule"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule_allowcmd_membership.sudo-allow-membership-1", "sudocmds.#", "3"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule_allowcmd_membership.sudo-allow-membership-1", "sudocmds.0", "/usr/bin/Testacc-Bash"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule_allowcmd_membership.sudo-allow-membership-1", "sudocmds.1", "/usr/bin/Testacc-Fish"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule_allowcmd_membership.sudo-allow-membership-1", "sudocmds.2", "/usr/bin/Testacc-Zsh"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule_allowcmd_membership.sudo-allow-membership-2", "name", "testacc-sudorule"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule_allowcmd_membership.sudo-allow-membership-2", "sudocmd_groups.#", "2"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule_allowcmd_membership.sudo-allow-membership-2", "sudocmd_groups.0", "Testacc Terminals"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule_allowcmd_membership.sudo-allow-membership-2", "sudocmd_groups.1", "Testacc Services"),
+				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPASudoCmd_resource(testSudoCmd1) + testAccFreeIPASudoCmd_resource(testSudoCmd2) + testAccFreeIPASudoCmd_resource(testSudoCmd3) + testAccFreeIPASudoCmdGrp_resource(testSudoCmdGrp) + testAccFreeIPASudoCmdGrp_resource(testSudoCmdGrp2) + testAccFreeIPASudoCmdGrpMembership_resource(testSudoCmdGrpMembership) + testAccFreeIPASudoRule_resource(testSudoRule) + testAccFreeIPASudoAllowCmdMembership_resource(testSudoAllowCmdMembership) + testAccFreeIPASudoAllowCmdMembership_resource(testSudoAllowCmdGrpMembership),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPASudoCmd_resource(testSudoCmd1) + testAccFreeIPASudoCmd_resource(testSudoCmd2) + testAccFreeIPASudoCmd_resource(testSudoCmd3) + testAccFreeIPASudoCmdGrp_resource(testSudoCmdGrp) + testAccFreeIPASudoCmdGrp_resource(testSudoCmdGrp2) + testAccFreeIPASudoCmdGrpMembership_resource(testSudoCmdGrpMembership) + testAccFreeIPASudoRule_resource(testSudoRule) + testAccFreeIPASudoAllowCmdMembership_resource(testSudoAllowCmdMembership) + testAccFreeIPASudoAllowCmdMembership_resource(testSudoAllowCmdGrpMembership) + testAccFreeIPASudoCmdGroup_datasource(testSudoCmdGrpDS) + testAccFreeIPASudoRule_datasource(testSudoDS),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.freeipa_sudo_cmdgroup.sudocmdgroup-1", "name", "Testacc Terminals"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_cmdgroup.sudocmdgroup-1", "description", "A set of terminals"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_cmdgroup.sudocmdgroup-1", "member_sudocmd.#", "3"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_cmdgroup.sudocmdgroup-1", "member_sudocmd.0", "/usr/bin/Testacc-Bash"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_cmdgroup.sudocmdgroup-1", "member_sudocmd.1", "/usr/bin/Testacc-Fish"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_cmdgroup.sudocmdgroup-1", "member_sudocmd.2", "/usr/bin/Testacc-Zsh"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "name", "testacc-sudorule"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "description", "A sudo rule for acceptance tests"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "member_allow_sudo_cmd.#", "3"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "member_allow_sudo_cmd.0", "/usr/bin/Testacc-Bash"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "member_allow_sudo_cmd.1", "/usr/bin/Testacc-Fish"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "member_allow_sudo_cmd.2", "/usr/bin/Testacc-Zsh"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "member_allow_sudo_cmdgroup.#", "2"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "member_allow_sudo_cmdgroup.0", "testacc terminals"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "member_allow_sudo_cmdgroup.1", "testacc services"),
+				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPASudoCmd_resource(testSudoCmd1) + testAccFreeIPASudoCmd_resource(testSudoCmd2) + testAccFreeIPASudoCmd_resource(testSudoCmd3) + testAccFreeIPASudoCmdGrp_resource(testSudoCmdGrp) + testAccFreeIPASudoCmdGrp_resource(testSudoCmdGrp2) + testAccFreeIPASudoCmdGrpMembership_resource(testSudoCmdGrpMembership) + testAccFreeIPASudoRule_resource(testSudoRule) + testAccFreeIPASudoAllowCmdMembership_resource(testSudoAllowCmdMembership) + testAccFreeIPASudoAllowCmdMembership_resource(testSudoAllowCmdGrpMembership) + testAccFreeIPASudoCmdGroup_datasource(testSudoCmdGrpDS) + testAccFreeIPASudoRule_datasource(testSudoDS),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 		},
 	})

--- a/freeipa/sudo_rule_denycmd_membership_resource.go
+++ b/freeipa/sudo_rule_denycmd_membership_resource.go
@@ -261,13 +261,13 @@ func (r *SudoRuleDenyCmdMembershipResource) Read(ctx context.Context, req resour
 
 	switch typeId {
 	case "srdc":
-		if res.Result.MemberdenycmdSudocmd == nil || !slices.Contains(*res.Result.MemberdenycmdSudocmd, cmdId) {
+		if res.Result.MemberdenycmdSudocmd == nil || !isStringListContainsCaseInsensistive(res.Result.MemberdenycmdSudocmd, &cmdId) {
 			tflog.Debug(ctx, "[DEBUG] Sudo rule denied command membership does not exist")
 			resp.State.RemoveResource(ctx)
 			return
 		}
 	case "srdcg":
-		if res.Result.MemberdenycmdSudocmdgroup == nil || !slices.Contains(*res.Result.MemberdenycmdSudocmdgroup, cmdId) {
+		if res.Result.MemberdenycmdSudocmdgroup == nil || !isStringListContainsCaseInsensistive(res.Result.MemberdenycmdSudocmdgroup, &cmdId) {
 			tflog.Debug(ctx, "[DEBUG] Sudo rule denied command membership does not exist")
 			resp.State.RemoveResource(ctx)
 			return
@@ -280,7 +280,7 @@ func (r *SudoRuleDenyCmdMembershipResource) Read(ctx context.Context, req resour
 				if err != nil {
 					tflog.Debug(ctx, fmt.Sprintf("[DEBUG] Read freeipa sudo command member commands failed with error %s", err))
 				}
-				if res.Result.MemberdenycmdSudocmd != nil && slices.Contains(*res.Result.MemberdenycmdSudocmd, val) {
+				if res.Result.MemberdenycmdSudocmd != nil && isStringListContainsCaseInsensistive(res.Result.MemberdenycmdSudocmd, &val) {
 					tflog.Debug(ctx, fmt.Sprintf("[DEBUG] Read freeipa sudo command member commands %s is present in results", val))
 					changedVals = append(changedVals, val)
 				}
@@ -298,7 +298,7 @@ func (r *SudoRuleDenyCmdMembershipResource) Read(ctx context.Context, req resour
 				if err != nil {
 					tflog.Debug(ctx, fmt.Sprintf("[DEBUG] Read freeipa sudo command member commands failed with error %s", err))
 				}
-				if res.Result.MemberdenycmdSudocmdgroup != nil && slices.Contains(*res.Result.MemberdenycmdSudocmdgroup, val) {
+				if res.Result.MemberdenycmdSudocmdgroup != nil && isStringListContainsCaseInsensistive(res.Result.MemberdenycmdSudocmdgroup, &val) {
 					tflog.Debug(ctx, fmt.Sprintf("[DEBUG] Read freeipa sudo command member commands %s is present in results", val))
 					changedVals = append(changedVals, val)
 				}

--- a/freeipa/sudo_rule_denycmd_membership_test.go
+++ b/freeipa/sudo_rule_denycmd_membership_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 func TestAccFreeIPASudoRuleDenyCmdMembership_simple(t *testing.T) {
@@ -73,6 +74,94 @@ func TestAccFreeIPASudoRuleDenyCmdMembership_simple(t *testing.T) {
 					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "member_deny_sudo_cmdgroup.#", "1"),
 					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "member_deny_sudo_cmdgroup.0", "testacc-terminals"),
 				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPASudoCmd_resource(testSudoCmd1) + testAccFreeIPASudoCmdGrp_resource(testSudoCmdGrp) + testAccFreeIPASudoCmdGrpMembership_resource(testSudoCmdGrpMembership) + testAccFreeIPASudoRule_resource(testSudoRule) + testAccFreeIPASudoDenyCmdMembership_resource(testSudoDenyCmdMembership) + testAccFreeIPASudoDenyCmdMembership_resource(testSudoDenyCmdGrpMembership) + testAccFreeIPASudoRule_datasource(testSudoDS),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccFreeIPASudoRuleDenyCmdMembership_simple_CaseInsensitive(t *testing.T) {
+	testSudoCmd1 := map[string]string{
+		"index":       "1",
+		"name":        "\"/usr/bin/testacc-bash\"",
+		"description": "\"The bash shell\"",
+	}
+	testSudoCmdGrp := map[string]string{
+		"index":       "1",
+		"name":        "\"TestACC-Terminals\"",
+		"description": "\"A set of terminals\"",
+	}
+	testSudoCmdGrpMembership := map[string]string{
+		"index":   "1",
+		"name":    "freeipa_sudo_cmdgroup.sudocmdgroup-1.name",
+		"sudocmd": "freeipa_sudo_cmd.sudocmd-1.name",
+	}
+	testSudoRule := map[string]string{
+		"index":       "1",
+		"name":        "\"TestACC-SudoRule\"",
+		"description": "\"A sudo rule for acceptance tests\"",
+	}
+	testSudoDenyCmdMembership := map[string]string{
+		"index":   "1",
+		"name":    "freeipa_sudo_rule.sudorule-1.name",
+		"sudocmd": "freeipa_sudo_cmd.sudocmd-1.name",
+	}
+	testSudoDenyCmdGrpMembership := map[string]string{
+		"index":         "2",
+		"name":          "freeipa_sudo_rule.sudorule-1.name",
+		"sudocmd_group": "freeipa_sudo_cmdgroup.sudocmdgroup-1.name",
+	}
+	testSudoDS := map[string]string{
+		"index": "1",
+		"name":  "freeipa_sudo_rule.sudorule-1.name",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPASudoCmd_resource(testSudoCmd1) + testAccFreeIPASudoCmdGrp_resource(testSudoCmdGrp) + testAccFreeIPASudoCmdGrpMembership_resource(testSudoCmdGrpMembership) + testAccFreeIPASudoRule_resource(testSudoRule) + testAccFreeIPASudoDenyCmdMembership_resource(testSudoDenyCmdMembership) + testAccFreeIPASudoDenyCmdMembership_resource(testSudoDenyCmdGrpMembership),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("freeipa_sudo_cmd.sudocmd-1", "name", "/usr/bin/testacc-bash"),
+					resource.TestCheckResourceAttr("freeipa_sudo_cmd.sudocmd-1", "description", "The bash shell"),
+					resource.TestCheckResourceAttr("freeipa_sudo_cmdgroup.sudocmdgroup-1", "name", "TestACC-Terminals"),
+					resource.TestCheckResourceAttr("freeipa_sudo_cmdgroup.sudocmdgroup-1", "description", "A set of terminals"),
+					resource.TestCheckResourceAttr("freeipa_sudo_cmdgroup_membership.sudocmdgroup-membership-1", "name", "TestACC-Terminals"),
+					resource.TestCheckResourceAttr("freeipa_sudo_cmdgroup_membership.sudocmdgroup-membership-1", "sudocmd", "/usr/bin/testacc-bash"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule.sudorule-1", "name", "TestACC-SudoRule"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule.sudorule-1", "description", "A sudo rule for acceptance tests"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule_denycmd_membership.sudo-deny-membership-1", "name", "TestACC-SudoRule"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule_denycmd_membership.sudo-deny-membership-1", "sudocmd", "/usr/bin/testacc-bash"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule_denycmd_membership.sudo-deny-membership-2", "name", "TestACC-SudoRule"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule_denycmd_membership.sudo-deny-membership-2", "sudocmd_group", "TestACC-Terminals"),
+				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPASudoCmd_resource(testSudoCmd1) + testAccFreeIPASudoCmdGrp_resource(testSudoCmdGrp) + testAccFreeIPASudoCmdGrpMembership_resource(testSudoCmdGrpMembership) + testAccFreeIPASudoRule_resource(testSudoRule) + testAccFreeIPASudoDenyCmdMembership_resource(testSudoDenyCmdMembership) + testAccFreeIPASudoDenyCmdMembership_resource(testSudoDenyCmdGrpMembership) + testAccFreeIPASudoRule_datasource(testSudoDS),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "name", "TestACC-SudoRule"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "description", "A sudo rule for acceptance tests"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "member_deny_sudo_cmd.#", "1"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "member_deny_sudo_cmd.0", "/usr/bin/testacc-bash"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "member_deny_sudo_cmdgroup.#", "1"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "member_deny_sudo_cmdgroup.0", "testacc-terminals"),
+				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPASudoCmd_resource(testSudoCmd1) + testAccFreeIPASudoCmdGrp_resource(testSudoCmdGrp) + testAccFreeIPASudoCmdGrpMembership_resource(testSudoCmdGrpMembership) + testAccFreeIPASudoRule_resource(testSudoRule) + testAccFreeIPASudoDenyCmdMembership_resource(testSudoDenyCmdMembership) + testAccFreeIPASudoDenyCmdMembership_resource(testSudoDenyCmdGrpMembership) + testAccFreeIPASudoRule_datasource(testSudoDS),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 		},
 	})
@@ -175,6 +264,124 @@ func TestAccFreeIPASudoRuleDenyCmdMembership_mutiple(t *testing.T) {
 					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "member_deny_sudo_cmdgroup.#", "1"),
 					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "member_deny_sudo_cmdgroup.0", "testacc-terminals"),
 				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPASudoCmd_resource(testSudoCmd1) + testAccFreeIPASudoCmd_resource(testSudoCmd2) + testAccFreeIPASudoCmd_resource(testSudoCmd3) + testAccFreeIPASudoCmdGrp_resource(testSudoCmdGrp) + testAccFreeIPASudoCmdGrpMembership_resource(testSudoCmdGrpMembership) + testAccFreeIPASudoRule_resource(testSudoRule) + testAccFreeIPASudoDenyCmdMembership_resource(testSudoDenyCmdMembership) + testAccFreeIPASudoDenyCmdMembership_resource(testSudoDenyCmdGrpMembership) + testAccFreeIPASudoCmdGroup_datasource(testSudoCmdGrpDS) + testAccFreeIPASudoRule_datasource(testSudoDS),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccFreeIPASudoRuleDenyCmdMembership_mutiple_CaseInsensitive(t *testing.T) {
+	testSudoCmd1 := map[string]string{
+		"index":       "1",
+		"name":        "\"/usr/bin/testacc-bash\"",
+		"description": "\"The bash shell\"",
+	}
+	testSudoCmd2 := map[string]string{
+		"index":       "2",
+		"name":        "\"/usr/bin/testacc-fish\"",
+		"description": "\"The fish shell\"",
+	}
+	testSudoCmd3 := map[string]string{
+		"index":       "3",
+		"name":        "\"/usr/bin/testacc-zsh\"",
+		"description": "\"The zsh shell\"",
+	}
+	testSudoCmdGrp := map[string]string{
+		"index":       "1",
+		"name":        "\"TestACC-Terminals\"",
+		"description": "\"A set of terminals\"",
+	}
+	testSudoCmdGrpMembership := map[string]string{
+		"index":       "1",
+		"name":        "freeipa_sudo_cmdgroup.sudocmdgroup-1.name",
+		"sudocmds":    "[freeipa_sudo_cmd.sudocmd-1.name,freeipa_sudo_cmd.sudocmd-2.name,freeipa_sudo_cmd.sudocmd-3.name]",
+		"indentifier": "multiplecmds",
+	}
+	testSudoRule := map[string]string{
+		"index":       "1",
+		"name":        "\"TestACC-SudoRule\"",
+		"description": "\"A sudo rule for acceptance tests\"",
+	}
+	testSudoDenyCmdMembership := map[string]string{
+		"index":      "1",
+		"name":       "freeipa_sudo_rule.sudorule-1.name",
+		"sudocmds":   "[freeipa_sudo_cmd.sudocmd-1.name]",
+		"identifier": "\"testacc-denycmds\"",
+	}
+	testSudoDenyCmdGrpMembership := map[string]string{
+		"index":          "2",
+		"name":           "freeipa_sudo_rule.sudorule-1.name",
+		"sudocmd_groups": "[freeipa_sudo_cmdgroup.sudocmdgroup-1.name]",
+		"identifier":     "\"testacc-denycmdgroups\"",
+	}
+	testSudoCmdGrpDS := map[string]string{
+		"index": "1",
+		"name":  "freeipa_sudo_cmdgroup.sudocmdgroup-1.name",
+	}
+	testSudoDS := map[string]string{
+		"index": "1",
+		"name":  "freeipa_sudo_rule.sudorule-1.name",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPASudoCmd_resource(testSudoCmd1) + testAccFreeIPASudoCmd_resource(testSudoCmd2) + testAccFreeIPASudoCmd_resource(testSudoCmd3) + testAccFreeIPASudoCmdGrp_resource(testSudoCmdGrp) + testAccFreeIPASudoCmdGrpMembership_resource(testSudoCmdGrpMembership) + testAccFreeIPASudoRule_resource(testSudoRule) + testAccFreeIPASudoDenyCmdMembership_resource(testSudoDenyCmdMembership) + testAccFreeIPASudoDenyCmdMembership_resource(testSudoDenyCmdGrpMembership),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("freeipa_sudo_cmd.sudocmd-1", "name", "/usr/bin/testacc-bash"),
+					resource.TestCheckResourceAttr("freeipa_sudo_cmd.sudocmd-1", "description", "The bash shell"),
+					resource.TestCheckResourceAttr("freeipa_sudo_cmd.sudocmd-2", "name", "/usr/bin/testacc-fish"),
+					resource.TestCheckResourceAttr("freeipa_sudo_cmd.sudocmd-2", "description", "The fish shell"),
+					resource.TestCheckResourceAttr("freeipa_sudo_cmd.sudocmd-3", "name", "/usr/bin/testacc-zsh"),
+					resource.TestCheckResourceAttr("freeipa_sudo_cmd.sudocmd-3", "description", "The zsh shell"),
+					resource.TestCheckResourceAttr("freeipa_sudo_cmdgroup.sudocmdgroup-1", "name", "TestACC-Terminals"),
+					resource.TestCheckResourceAttr("freeipa_sudo_cmdgroup.sudocmdgroup-1", "description", "A set of terminals"),
+					resource.TestCheckResourceAttr("freeipa_sudo_cmdgroup_membership.sudocmdgroup-membership-1", "name", "TestACC-Terminals"),
+					resource.TestCheckResourceAttr("freeipa_sudo_cmdgroup_membership.sudocmdgroup-membership-1", "sudocmds.#", "3"),
+					resource.TestCheckResourceAttr("freeipa_sudo_cmdgroup_membership.sudocmdgroup-membership-1", "sudocmds.0", "/usr/bin/testacc-bash"),
+					resource.TestCheckResourceAttr("freeipa_sudo_cmdgroup_membership.sudocmdgroup-membership-1", "sudocmds.1", "/usr/bin/testacc-fish"),
+					resource.TestCheckResourceAttr("freeipa_sudo_cmdgroup_membership.sudocmdgroup-membership-1", "sudocmds.2", "/usr/bin/testacc-zsh"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule_denycmd_membership.sudo-deny-membership-1", "name", "TestACC-SudoRule"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule_denycmd_membership.sudo-deny-membership-1", "sudocmds.#", "1"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule_denycmd_membership.sudo-deny-membership-1", "sudocmds.0", "/usr/bin/testacc-bash"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule_denycmd_membership.sudo-deny-membership-2", "name", "TestACC-SudoRule"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule_denycmd_membership.sudo-deny-membership-2", "sudocmd_groups.#", "1"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule_denycmd_membership.sudo-deny-membership-2", "sudocmd_groups.0", "TestACC-Terminals"),
+				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPASudoCmd_resource(testSudoCmd1) + testAccFreeIPASudoCmd_resource(testSudoCmd2) + testAccFreeIPASudoCmd_resource(testSudoCmd3) + testAccFreeIPASudoCmdGrp_resource(testSudoCmdGrp) + testAccFreeIPASudoCmdGrpMembership_resource(testSudoCmdGrpMembership) + testAccFreeIPASudoRule_resource(testSudoRule) + testAccFreeIPASudoDenyCmdMembership_resource(testSudoDenyCmdMembership) + testAccFreeIPASudoDenyCmdMembership_resource(testSudoDenyCmdGrpMembership) + testAccFreeIPASudoCmdGroup_datasource(testSudoCmdGrpDS) + testAccFreeIPASudoRule_datasource(testSudoDS),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.freeipa_sudo_cmdgroup.sudocmdgroup-1", "name", "TestACC-Terminals"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_cmdgroup.sudocmdgroup-1", "description", "A set of terminals"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_cmdgroup.sudocmdgroup-1", "member_sudocmd.#", "3"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_cmdgroup.sudocmdgroup-1", "member_sudocmd.0", "/usr/bin/testacc-bash"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_cmdgroup.sudocmdgroup-1", "member_sudocmd.1", "/usr/bin/testacc-fish"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_cmdgroup.sudocmdgroup-1", "member_sudocmd.2", "/usr/bin/testacc-zsh"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "name", "TestACC-SudoRule"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "description", "A sudo rule for acceptance tests"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "member_deny_sudo_cmd.#", "1"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "member_deny_sudo_cmd.0", "/usr/bin/testacc-bash"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "member_deny_sudo_cmdgroup.#", "1"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "member_deny_sudo_cmdgroup.0", "testacc-terminals"),
+				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPASudoCmd_resource(testSudoCmd1) + testAccFreeIPASudoCmd_resource(testSudoCmd2) + testAccFreeIPASudoCmd_resource(testSudoCmd3) + testAccFreeIPASudoCmdGrp_resource(testSudoCmdGrp) + testAccFreeIPASudoCmdGrpMembership_resource(testSudoCmdGrpMembership) + testAccFreeIPASudoRule_resource(testSudoRule) + testAccFreeIPASudoDenyCmdMembership_resource(testSudoDenyCmdMembership) + testAccFreeIPASudoDenyCmdMembership_resource(testSudoDenyCmdGrpMembership) + testAccFreeIPASudoCmdGroup_datasource(testSudoCmdGrpDS) + testAccFreeIPASudoRule_datasource(testSudoDS),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 		},
 	})

--- a/freeipa/sudo_rule_host_membership_resource.go
+++ b/freeipa/sudo_rule_host_membership_resource.go
@@ -261,13 +261,13 @@ func (r *SudoRuleHostMembershipResource) Read(ctx context.Context, req resource.
 
 	switch typeId {
 	case "srh":
-		if res.Result.MemberhostHost == nil || !slices.Contains(*res.Result.MemberhostHost, cmdId) {
+		if res.Result.MemberhostHost == nil || !isStringListContainsCaseInsensistive(res.Result.MemberhostHost, &cmdId) {
 			tflog.Debug(ctx, "[DEBUG] Sudo rule host membership does not exist")
 			resp.State.RemoveResource(ctx)
 			return
 		}
 	case "srhg":
-		if res.Result.MemberhostHostgroup == nil || !slices.Contains(*res.Result.MemberhostHostgroup, cmdId) {
+		if res.Result.MemberhostHostgroup == nil || !isStringListContainsCaseInsensistive(res.Result.MemberhostHostgroup, &cmdId) {
 			tflog.Debug(ctx, "[DEBUG] Sudo rule host group membership does not exist")
 			resp.State.RemoveResource(ctx)
 			return
@@ -280,7 +280,7 @@ func (r *SudoRuleHostMembershipResource) Read(ctx context.Context, req resource.
 				if err != nil {
 					tflog.Debug(ctx, fmt.Sprintf("[DEBUG] Read freeipa sudo host member failed with error %s", err))
 				}
-				if res.Result.MemberhostHost != nil && slices.Contains(*res.Result.MemberhostHost, val) {
+				if res.Result.MemberhostHost != nil && isStringListContainsCaseInsensistive(res.Result.MemberhostHost, &val) {
 					tflog.Debug(ctx, fmt.Sprintf("[DEBUG] Read freeipa sudo host member %s is present in results", val))
 					changedVals = append(changedVals, val)
 				}
@@ -298,7 +298,7 @@ func (r *SudoRuleHostMembershipResource) Read(ctx context.Context, req resource.
 				if err != nil {
 					tflog.Debug(ctx, fmt.Sprintf("[DEBUG] Read freeipa sudo host member commands failed with error %s", err))
 				}
-				if res.Result.MemberhostHostgroup != nil && slices.Contains(*res.Result.MemberhostHostgroup, val) {
+				if res.Result.MemberhostHostgroup != nil && isStringListContainsCaseInsensistive(res.Result.MemberhostHostgroup, &val) {
 					tflog.Debug(ctx, fmt.Sprintf("[DEBUG] Read freeipa sudo host member commands %s is present in results", val))
 					changedVals = append(changedVals, val)
 				}

--- a/freeipa/sudo_rule_host_membership_test.go
+++ b/freeipa/sudo_rule_host_membership_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 func TestAccFreeIPASudoRuleHostMembership_simple(t *testing.T) {
@@ -65,6 +66,86 @@ func TestAccFreeIPASudoRuleHostMembership_simple(t *testing.T) {
 					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "member_hostgroup.#", "1"),
 					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "member_hostgroup.0", "testacc-hostgroup"),
 				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPADNSZone_resource(testZone) + testAccFreeIPAHost_resource(testMemberHost) + testAccFreeIPAHostGroup_resource(testHostGroup) + testAccFreeIPASudoRule_resource(testSudoRule) + testAccFreeIPASudoRuleHostMembership_resource(testSudoHostMembership) + testAccFreeIPASudoRuleHostMembership_resource(testSudoHostGrpMembership) + testAccFreeIPASudoRule_datasource(testSudoDS),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccFreeIPASudoRuleHostMembership_simple_CaseInsensitive(t *testing.T) {
+	testZone := map[string]string{
+		"index":     "0",
+		"zone_name": "\"testacc.ipatest.lan\"",
+	}
+	testMemberHost := map[string]string{
+		"index":      "0",
+		"name":       "\"TestACC-Host-1.${freeipa_dns_zone.dns-zone-0.zone_name}\"",
+		"ip_address": "\"192.168.10.65\"",
+	}
+	testHostGroup := map[string]string{
+		"index": "0",
+		"name":  "\"TestACC-HostGroup\"",
+	}
+	testSudoRule := map[string]string{
+		"index":       "1",
+		"name":        "\"TestACC-SudoRule\"",
+		"description": "\"A sudo rule for acceptance tests\"",
+	}
+	testSudoHostMembership := map[string]string{
+		"index": "1",
+		"name":  "freeipa_sudo_rule.sudorule-1.name",
+		"host":  "freeipa_host.host-0.name",
+	}
+	testSudoHostGrpMembership := map[string]string{
+		"index":     "2",
+		"name":      "freeipa_sudo_rule.sudorule-1.name",
+		"hostgroup": "freeipa_hostgroup.hostgroup-0.name",
+	}
+	testSudoDS := map[string]string{
+		"index": "1",
+		"name":  "freeipa_sudo_rule.sudorule-1.name",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPADNSZone_resource(testZone) + testAccFreeIPAHost_resource(testMemberHost) + testAccFreeIPAHostGroup_resource(testHostGroup) + testAccFreeIPASudoRule_resource(testSudoRule) + testAccFreeIPASudoRuleHostMembership_resource(testSudoHostMembership) + testAccFreeIPASudoRuleHostMembership_resource(testSudoHostGrpMembership),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("freeipa_sudo_rule.sudorule-1", "name", "TestACC-SudoRule"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule.sudorule-1", "description", "A sudo rule for acceptance tests"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule_host_membership.sudo-host-membership-1", "name", "TestACC-SudoRule"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule_host_membership.sudo-host-membership-1", "host", "TestACC-Host-1.testacc.ipatest.lan"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule_host_membership.sudo-host-membership-2", "name", "TestACC-SudoRule"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule_host_membership.sudo-host-membership-2", "hostgroup", "TestACC-HostGroup"),
+				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPADNSZone_resource(testZone) + testAccFreeIPAHost_resource(testMemberHost) + testAccFreeIPAHostGroup_resource(testHostGroup) + testAccFreeIPASudoRule_resource(testSudoRule) + testAccFreeIPASudoRuleHostMembership_resource(testSudoHostMembership) + testAccFreeIPASudoRuleHostMembership_resource(testSudoHostGrpMembership) + testAccFreeIPASudoRule_datasource(testSudoDS),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "name", "TestACC-SudoRule"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "description", "A sudo rule for acceptance tests"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "member_host.#", "1"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "member_host.0", "testacc-host-1.testacc.ipatest.lan"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "member_hostgroup.#", "1"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "member_hostgroup.0", "testacc-hostgroup"),
+				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPADNSZone_resource(testZone) + testAccFreeIPAHost_resource(testMemberHost) + testAccFreeIPAHostGroup_resource(testHostGroup) + testAccFreeIPASudoRule_resource(testSudoRule) + testAccFreeIPASudoRuleHostMembership_resource(testSudoHostMembership) + testAccFreeIPASudoRuleHostMembership_resource(testSudoHostGrpMembership) + testAccFreeIPASudoRule_datasource(testSudoDS),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 		},
 	})
@@ -133,6 +214,90 @@ func TestAccFreeIPASudoRuleHostMembership_mutiple(t *testing.T) {
 					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "member_hostgroup.#", "1"),
 					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "member_hostgroup.0", "testacc-hostgroup"),
 				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPADNSZone_resource(testZone) + testAccFreeIPAHost_resource(testMemberHost) + testAccFreeIPAHostGroup_resource(testHostGroup) + testAccFreeIPASudoRule_resource(testSudoRule) + testAccFreeIPASudoRuleHostMembership_resource(testSudoHostMembership) + testAccFreeIPASudoRuleHostMembership_resource(testSudoHostGrpMembership) + testAccFreeIPASudoRule_datasource(testSudoDS),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccFreeIPASudoRuleHostMembership_mutiple_CaseInsensitive(t *testing.T) {
+	testZone := map[string]string{
+		"index":     "0",
+		"zone_name": "\"testacc.ipatest.lan\"",
+	}
+	testMemberHost := map[string]string{
+		"index":      "0",
+		"name":       "\"TestACC-Host-1.${freeipa_dns_zone.dns-zone-0.zone_name}\"",
+		"ip_address": "\"192.168.10.65\"",
+	}
+	testHostGroup := map[string]string{
+		"index": "0",
+		"name":  "\"TestACC-HostGroup\"",
+	}
+	testSudoRule := map[string]string{
+		"index":       "1",
+		"name":        "\"TestACC-SudoRule\"",
+		"description": "\"A sudo rule for acceptance tests\"",
+	}
+	testSudoHostMembership := map[string]string{
+		"index":      "1",
+		"name":       "freeipa_sudo_rule.sudorule-1.name",
+		"hosts":      "[freeipa_host.host-0.name]",
+		"identifier": "\"hostmembers-1\"",
+	}
+	testSudoHostGrpMembership := map[string]string{
+		"index":      "2",
+		"name":       "freeipa_sudo_rule.sudorule-1.name",
+		"hostgroups": "[freeipa_hostgroup.hostgroup-0.name]",
+		"identifier": "\"hostgroupmembers-2\"",
+	}
+	testSudoDS := map[string]string{
+		"index": "1",
+		"name":  "freeipa_sudo_rule.sudorule-1.name",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPADNSZone_resource(testZone) + testAccFreeIPAHost_resource(testMemberHost) + testAccFreeIPAHostGroup_resource(testHostGroup) + testAccFreeIPASudoRule_resource(testSudoRule) + testAccFreeIPASudoRuleHostMembership_resource(testSudoHostMembership) + testAccFreeIPASudoRuleHostMembership_resource(testSudoHostGrpMembership),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("freeipa_sudo_rule.sudorule-1", "name", "TestACC-SudoRule"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule.sudorule-1", "description", "A sudo rule for acceptance tests"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule_host_membership.sudo-host-membership-1", "name", "TestACC-SudoRule"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule_host_membership.sudo-host-membership-1", "hosts.#", "1"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule_host_membership.sudo-host-membership-1", "hosts.0", "TestACC-Host-1.testacc.ipatest.lan"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule_host_membership.sudo-host-membership-2", "name", "TestACC-SudoRule"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule_host_membership.sudo-host-membership-2", "hostgroups.#", "1"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule_host_membership.sudo-host-membership-2", "hostgroups.0", "TestACC-HostGroup"),
+				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPADNSZone_resource(testZone) + testAccFreeIPAHost_resource(testMemberHost) + testAccFreeIPAHostGroup_resource(testHostGroup) + testAccFreeIPASudoRule_resource(testSudoRule) + testAccFreeIPASudoRuleHostMembership_resource(testSudoHostMembership) + testAccFreeIPASudoRuleHostMembership_resource(testSudoHostGrpMembership) + testAccFreeIPASudoRule_datasource(testSudoDS),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "name", "TestACC-SudoRule"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "description", "A sudo rule for acceptance tests"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "member_host.#", "1"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "member_host.0", "testacc-host-1.testacc.ipatest.lan"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "member_hostgroup.#", "1"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "member_hostgroup.0", "testacc-hostgroup"),
+				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPADNSZone_resource(testZone) + testAccFreeIPAHost_resource(testMemberHost) + testAccFreeIPAHostGroup_resource(testHostGroup) + testAccFreeIPASudoRule_resource(testSudoRule) + testAccFreeIPASudoRuleHostMembership_resource(testSudoHostMembership) + testAccFreeIPASudoRuleHostMembership_resource(testSudoHostGrpMembership) + testAccFreeIPASudoRule_datasource(testSudoDS),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 		},
 	})

--- a/freeipa/sudo_rule_option_test.go
+++ b/freeipa/sudo_rule_option_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 func TestAccFreeIPASudoRuleOption_simple(t *testing.T) {
@@ -41,6 +42,62 @@ func TestAccFreeIPASudoRuleOption_simple(t *testing.T) {
 					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "option.#", "1"),
 					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "option.0", "!authenticate"),
 				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPASudoRule_resource(testSudoRule) + testAccFreeIPASudoRuleOption_resource(testSudoRuleOption) + testAccFreeIPASudoRule_datasource(testSudoDS),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccFreeIPASudoRuleOption_simple_CaseInsensitive(t *testing.T) {
+	testSudoRule := map[string]string{
+		"index":       "1",
+		"name":        "\"TestACC-SudoRule\"",
+		"description": "\"A sudo rule for acceptance tests\"",
+	}
+	testSudoRuleOption := map[string]string{
+		"index":  "1",
+		"name":   "freeipa_sudo_rule.sudorule-1.name",
+		"option": "\"!authenticate\"",
+	}
+	testSudoDS := map[string]string{
+		"index": "1",
+		"name":  "freeipa_sudo_rule.sudorule-1.name",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPASudoRule_resource(testSudoRule) + testAccFreeIPASudoRuleOption_resource(testSudoRuleOption),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("freeipa_sudo_rule.sudorule-1", "name", "TestACC-SudoRule"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule.sudorule-1", "description", "A sudo rule for acceptance tests"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule_option.sudorule-option-1", "option", "!authenticate"),
+				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPASudoRule_resource(testSudoRule) + testAccFreeIPASudoRuleOption_resource(testSudoRuleOption) + testAccFreeIPASudoRule_datasource(testSudoDS),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "name", "TestACC-SudoRule"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "option.#", "1"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "option.0", "!authenticate"),
+				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPASudoRule_resource(testSudoRule) + testAccFreeIPASudoRuleOption_resource(testSudoRuleOption) + testAccFreeIPASudoRule_datasource(testSudoDS),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 		},
 	})

--- a/freeipa/sudo_rule_runasgroup_membership_resource.go
+++ b/freeipa/sudo_rule_runasgroup_membership_resource.go
@@ -212,7 +212,7 @@ func (r *SudoRuleRunAsGroupMembershipResource) Read(ctx context.Context, req res
 
 	switch typeId {
 	case "srraug":
-		if res.Result.IpasudorunasgroupGroup == nil || !slices.Contains(*res.Result.IpasudorunasgroupGroup, grpId) {
+		if res.Result.IpasudorunasgroupGroup == nil || !isStringListContainsCaseInsensistive(res.Result.IpasudorunasgroupGroup, &grpId) {
 			tflog.Debug(ctx, "[DEBUG] Sudo rule runasgroup membership does not exist")
 			resp.State.RemoveResource(ctx)
 			return
@@ -225,7 +225,7 @@ func (r *SudoRuleRunAsGroupMembershipResource) Read(ctx context.Context, req res
 				if err != nil {
 					tflog.Debug(ctx, fmt.Sprintf("[DEBUG] Read freeipa sudo command member commands failed with error %s", err))
 				}
-				if res.Result.IpasudorunasgroupGroup != nil && slices.Contains(*res.Result.IpasudorunasgroupGroup, val) {
+				if res.Result.IpasudorunasgroupGroup != nil && isStringListContainsCaseInsensistive(res.Result.IpasudorunasgroupGroup, &val) {
 					tflog.Debug(ctx, fmt.Sprintf("[DEBUG] Read freeipa sudo command member commands %s is present in results", val))
 					changedVals = append(changedVals, val)
 				}

--- a/freeipa/sudo_rule_runasgroup_membership_test.go
+++ b/freeipa/sudo_rule_runasgroup_membership_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 func TestAccFreeIPASudoRuleRunAsGroupMembership_simple(t *testing.T) {
@@ -48,6 +49,69 @@ func TestAccFreeIPASudoRuleRunAsGroupMembership_simple(t *testing.T) {
 					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "runasgroup.#", "1"),
 					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "runasgroup.0", "testacc-group-0"),
 				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAGroup_resource(testGroup) + testAccFreeIPASudoRule_resource(testSudoRule) + testAccFreeIPASudoRuleRunAsGroupMembership_resource(testSudoRunAsGroupMembership) + testAccFreeIPASudoRule_datasource(testSudoDS),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccFreeIPASudoRuleRunAsGroupMembership_simple_CaseInsensitive(t *testing.T) {
+	testGroup := map[string]string{
+		"index":       "0",
+		"name":        "\"TestACC-Group-0\"",
+		"description": "\"User group test 0\"",
+	}
+	testSudoRule := map[string]string{
+		"index":       "1",
+		"name":        "\"TestACC-SudoRule\"",
+		"description": "\"A sudo rule for acceptance tests\"",
+	}
+	testSudoRunAsGroupMembership := map[string]string{
+		"index":      "1",
+		"name":       "freeipa_sudo_rule.sudorule-1.name",
+		"runasgroup": "freeipa_group.group-0.name",
+	}
+	testSudoDS := map[string]string{
+		"index": "1",
+		"name":  "freeipa_sudo_rule.sudorule-1.name",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAGroup_resource(testGroup) + testAccFreeIPASudoRule_resource(testSudoRule) + testAccFreeIPASudoRuleRunAsGroupMembership_resource(testSudoRunAsGroupMembership),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("freeipa_sudo_rule.sudorule-1", "name", "TestACC-SudoRule"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule.sudorule-1", "description", "A sudo rule for acceptance tests"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule_runasgroup_membership.sudorule-runasgroup-membership-1", "name", "TestACC-SudoRule"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule_runasgroup_membership.sudorule-runasgroup-membership-1", "runasgroup", "TestACC-Group-0"),
+				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAGroup_resource(testGroup) + testAccFreeIPASudoRule_resource(testSudoRule) + testAccFreeIPASudoRuleRunAsGroupMembership_resource(testSudoRunAsGroupMembership) + testAccFreeIPASudoRule_datasource(testSudoDS),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "name", "TestACC-SudoRule"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "description", "A sudo rule for acceptance tests"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "runasgroup.#", "1"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "runasgroup.0", "testacc-group-0"),
+				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAGroup_resource(testGroup) + testAccFreeIPASudoRule_resource(testSudoRule) + testAccFreeIPASudoRuleRunAsGroupMembership_resource(testSudoRunAsGroupMembership) + testAccFreeIPASudoRule_datasource(testSudoDS),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 		},
 	})
@@ -97,6 +161,71 @@ func TestAccFreeIPASudoRuleRunAsGroupMembership_multiple(t *testing.T) {
 					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "runasgroup.#", "1"),
 					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "runasgroup.0", "testacc-group-0"),
 				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAGroup_resource(testGroup) + testAccFreeIPASudoRule_resource(testSudoRule) + testAccFreeIPASudoRuleRunAsGroupMembership_resource(testSudoRunAsGroupMembership) + testAccFreeIPASudoRule_datasource(testSudoDS),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccFreeIPASudoRuleRunAsGroupMembership_multiple_CaseInsensitive(t *testing.T) {
+	testGroup := map[string]string{
+		"index":       "0",
+		"name":        "\"TestACC-Group-0\"",
+		"description": "\"User group test 0\"",
+	}
+	testSudoRule := map[string]string{
+		"index":       "1",
+		"name":        "\"TestACC-SudoRule\"",
+		"description": "\"A sudo rule for acceptance tests\"",
+	}
+	testSudoRunAsGroupMembership := map[string]string{
+		"index":       "1",
+		"name":        "freeipa_sudo_rule.sudorule-1.name",
+		"runasgroups": "[freeipa_group.group-0.name]",
+		"identifier":  "\"runasgroup0\"",
+	}
+	testSudoDS := map[string]string{
+		"index": "1",
+		"name":  "freeipa_sudo_rule.sudorule-1.name",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAGroup_resource(testGroup) + testAccFreeIPASudoRule_resource(testSudoRule) + testAccFreeIPASudoRuleRunAsGroupMembership_resource(testSudoRunAsGroupMembership),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("freeipa_sudo_rule.sudorule-1", "name", "TestACC-SudoRule"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule.sudorule-1", "description", "A sudo rule for acceptance tests"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule_runasgroup_membership.sudorule-runasgroup-membership-1", "name", "TestACC-SudoRule"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule_runasgroup_membership.sudorule-runasgroup-membership-1", "runasgroups.#", "1"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule_runasgroup_membership.sudorule-runasgroup-membership-1", "runasgroups.0", "TestACC-Group-0"),
+				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAGroup_resource(testGroup) + testAccFreeIPASudoRule_resource(testSudoRule) + testAccFreeIPASudoRuleRunAsGroupMembership_resource(testSudoRunAsGroupMembership) + testAccFreeIPASudoRule_datasource(testSudoDS),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "name", "TestACC-SudoRule"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "description", "A sudo rule for acceptance tests"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "runasgroup.#", "1"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "runasgroup.0", "testacc-group-0"),
+				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAGroup_resource(testGroup) + testAccFreeIPASudoRule_resource(testSudoRule) + testAccFreeIPASudoRuleRunAsGroupMembership_resource(testSudoRunAsGroupMembership) + testAccFreeIPASudoRule_datasource(testSudoDS),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 		},
 	})

--- a/freeipa/sudo_rule_runasuser_membership_resource.go
+++ b/freeipa/sudo_rule_runasuser_membership_resource.go
@@ -212,7 +212,7 @@ func (r *SudoRuleRunAsUserMembershipResource) Read(ctx context.Context, req reso
 
 	switch typeId {
 	case "srrau":
-		if res.Result.IpasudorunasUser == nil || !slices.Contains(*res.Result.IpasudorunasUser, usrId) {
+		if res.Result.IpasudorunasUser == nil || !isStringListContainsCaseInsensistive(res.Result.IpasudorunasUser, &usrId) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
@@ -225,7 +225,7 @@ func (r *SudoRuleRunAsUserMembershipResource) Read(ctx context.Context, req reso
 					if err != nil {
 						tflog.Debug(ctx, fmt.Sprintf("[DEBUG] Read freeipa sudo runasgroup membership failed with error %s", err))
 					}
-					if slices.Contains(*res.Result.IpasudorunasUser, val) {
+					if isStringListContainsCaseInsensistive(res.Result.IpasudorunasUser, &val) {
 						tflog.Debug(ctx, fmt.Sprintf("[DEBUG] Read freeipa sudo runasgroup membership %s is present in results", val))
 						changedVals = append(changedVals, val)
 					}

--- a/freeipa/sudo_rule_runasuser_membership_test.go
+++ b/freeipa/sudo_rule_runasuser_membership_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 func TestAccFreeIPASudoRuleRunAsUserMembership_simple(t *testing.T) {
@@ -49,6 +50,70 @@ func TestAccFreeIPASudoRuleRunAsUserMembership_simple(t *testing.T) {
 					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "runasuser.#", "1"),
 					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "runasuser.0", "testacc-user-0"),
 				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAUser_resource(testUser) + testAccFreeIPASudoRule_resource(testSudoRule) + testAccFreeIPASudoRuleRunAsUserMembership_resource(testSudoRunAsUserMembership) + testAccFreeIPASudoRule_datasource(testSudoDS),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccFreeIPASudoRuleRunAsUserMembership_simple_CaseInsensitive(t *testing.T) {
+	testUser := map[string]string{
+		"index":     "0",
+		"login":     "\"TestACC-User-0\"",
+		"firstname": "\"Test\"",
+		"lastname":  "\"User0\"",
+	}
+	testSudoRule := map[string]string{
+		"index":       "1",
+		"name":        "\"TestACC-SudoRule\"",
+		"description": "\"A sudo rule for acceptance tests\"",
+	}
+	testSudoRunAsUserMembership := map[string]string{
+		"index":     "1",
+		"name":      "freeipa_sudo_rule.sudorule-1.name",
+		"runasuser": "freeipa_user.user-0.name",
+	}
+	testSudoDS := map[string]string{
+		"index": "1",
+		"name":  "freeipa_sudo_rule.sudorule-1.name",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAUser_resource(testUser) + testAccFreeIPASudoRule_resource(testSudoRule) + testAccFreeIPASudoRuleRunAsUserMembership_resource(testSudoRunAsUserMembership),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("freeipa_sudo_rule.sudorule-1", "name", "TestACC-SudoRule"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule.sudorule-1", "description", "A sudo rule for acceptance tests"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule_runasuser_membership.sudorule-runasuser-membership-1", "name", "TestACC-SudoRule"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule_runasuser_membership.sudorule-runasuser-membership-1", "runasuser", "TestACC-User-0"),
+				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAUser_resource(testUser) + testAccFreeIPASudoRule_resource(testSudoRule) + testAccFreeIPASudoRuleRunAsUserMembership_resource(testSudoRunAsUserMembership) + testAccFreeIPASudoRule_datasource(testSudoDS),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "name", "TestACC-SudoRule"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "description", "A sudo rule for acceptance tests"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "runasuser.#", "1"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "runasuser.0", "testacc-user-0"),
+				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAUser_resource(testUser) + testAccFreeIPASudoRule_resource(testSudoRule) + testAccFreeIPASudoRuleRunAsUserMembership_resource(testSudoRunAsUserMembership) + testAccFreeIPASudoRule_datasource(testSudoDS),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 		},
 	})
@@ -99,6 +164,72 @@ func TestAccFreeIPASudoRuleRunAsUserMembership_multiple(t *testing.T) {
 					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "runasuser.#", "1"),
 					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "runasuser.0", "testacc-user-0"),
 				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAUser_resource(testUser) + testAccFreeIPASudoRule_resource(testSudoRule) + testAccFreeIPASudoRuleRunAsUserMembership_resource(testSudoRunAsUserMembership) + testAccFreeIPASudoRule_datasource(testSudoDS),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccFreeIPASudoRuleRunAsUserMembership_multiple_CaseInsensitive(t *testing.T) {
+	testUser := map[string]string{
+		"index":     "0",
+		"login":     "\"TestACC-User-0\"",
+		"firstname": "\"Test\"",
+		"lastname":  "\"User0\"",
+	}
+	testSudoRule := map[string]string{
+		"index":       "1",
+		"name":        "\"TestACC-SudoRule\"",
+		"description": "\"A sudo rule for acceptance tests\"",
+	}
+	testSudoRunAsUserMembership := map[string]string{
+		"index":      "1",
+		"name":       "freeipa_sudo_rule.sudorule-1.name",
+		"runasusers": "[freeipa_user.user-0.name]",
+		"identifier": "\"runasuser0\"",
+	}
+	testSudoDS := map[string]string{
+		"index": "1",
+		"name":  "freeipa_sudo_rule.sudorule-1.name",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAUser_resource(testUser) + testAccFreeIPASudoRule_resource(testSudoRule) + testAccFreeIPASudoRuleRunAsUserMembership_resource(testSudoRunAsUserMembership),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("freeipa_sudo_rule.sudorule-1", "name", "TestACC-SudoRule"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule.sudorule-1", "description", "A sudo rule for acceptance tests"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule_runasuser_membership.sudorule-runasuser-membership-1", "name", "TestACC-SudoRule"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule_runasuser_membership.sudorule-runasuser-membership-1", "runasusers.#", "1"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule_runasuser_membership.sudorule-runasuser-membership-1", "runasusers.0", "TestACC-User-0"),
+				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAUser_resource(testUser) + testAccFreeIPASudoRule_resource(testSudoRule) + testAccFreeIPASudoRuleRunAsUserMembership_resource(testSudoRunAsUserMembership) + testAccFreeIPASudoRule_datasource(testSudoDS),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "name", "TestACC-SudoRule"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "description", "A sudo rule for acceptance tests"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "runasuser.#", "1"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "runasuser.0", "testacc-user-0"),
+				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAUser_resource(testUser) + testAccFreeIPASudoRule_resource(testSudoRule) + testAccFreeIPASudoRuleRunAsUserMembership_resource(testSudoRunAsUserMembership) + testAccFreeIPASudoRule_datasource(testSudoDS),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 		},
 	})

--- a/freeipa/sudo_rule_test.go
+++ b/freeipa/sudo_rule_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 func TestAccFreeIPASudoRule_simple(t *testing.T) {
@@ -48,6 +49,14 @@ func TestAccFreeIPASudoRule_simple(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPASudoRule_resource(testSudoRule) + testAccFreeIPASudoRule_datasource(testSudoDS),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			{
 				Config: testAccFreeIPAProvider() + testAccFreeIPASudoRule_resource(testSudoRuleModified),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("freeipa_sudo_rule.sudorule-1", "name", "testacc-sudorule"),
@@ -74,6 +83,57 @@ func TestAccFreeIPASudoRule_simple(t *testing.T) {
 					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "runasgroupcategory", "all"),
 					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "order", "5"),
 				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPASudoRule_resource(testSudoRuleModified) + testAccFreeIPASudoRule_datasource(testSudoDS),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccFreeIPASudoRule_simple_CaseInsensitive(t *testing.T) {
+	testSudoRule := map[string]string{
+		"index":       "1",
+		"name":        "\"TestACC SudoRule\"",
+		"description": "\"A sudo rule for acceptance tests\"",
+	}
+	testSudoDS := map[string]string{
+		"index": "1",
+		"name":  "freeipa_sudo_rule.sudorule-1.name",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPASudoRule_resource(testSudoRule),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("freeipa_sudo_rule.sudorule-1", "id", "TestACC SudoRule"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule.sudorule-1", "name", "TestACC SudoRule"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule.sudorule-1", "description", "A sudo rule for acceptance tests"),
+				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPASudoRule_resource(testSudoRule) + testAccFreeIPASudoRule_datasource(testSudoDS),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("freeipa_sudo_rule.sudorule-1", "id", "TestACC SudoRule"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "name", "TestACC SudoRule"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "description", "A sudo rule for acceptance tests"),
+				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPASudoRule_resource(testSudoRule) + testAccFreeIPASudoRule_datasource(testSudoDS),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 		},
 	})

--- a/freeipa/sudo_rule_user_membership_resource.go
+++ b/freeipa/sudo_rule_user_membership_resource.go
@@ -261,12 +261,12 @@ func (r *SudoRuleUserMembershipResource) Read(ctx context.Context, req resource.
 
 	switch typeId {
 	case "sru":
-		if res.Result.MemberuserUser == nil || !slices.Contains(*res.Result.MemberuserUser, cmdId) {
+		if res.Result.MemberuserUser == nil || !isStringListContainsCaseInsensistive(res.Result.MemberuserUser, &cmdId) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
 	case "srug":
-		if res.Result.MemberuserGroup == nil || !slices.Contains(*res.Result.MemberuserGroup, cmdId) {
+		if res.Result.MemberuserGroup == nil || !isStringListContainsCaseInsensistive(res.Result.MemberuserGroup, &cmdId) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
@@ -282,7 +282,7 @@ func (r *SudoRuleUserMembershipResource) Read(ctx context.Context, req resource.
 					if err != nil {
 						tflog.Debug(ctx, fmt.Sprintf("[DEBUG] Read freeipa sudo user member failed with error %s", err))
 					}
-					if res.Result.MemberuserUser != nil && slices.Contains(*res.Result.MemberuserUser, val) {
+					if res.Result.MemberuserUser != nil && isStringListContainsCaseInsensistive(res.Result.MemberuserUser, &val) {
 						tflog.Debug(ctx, fmt.Sprintf("[DEBUG] Read freeipa sudo user member %s is present in results", val))
 						changedVals = append(changedVals, val)
 					}
@@ -300,7 +300,7 @@ func (r *SudoRuleUserMembershipResource) Read(ctx context.Context, req resource.
 					if err != nil {
 						tflog.Debug(ctx, fmt.Sprintf("[DEBUG] Read freeipa sudo user group member failed with error %s", err))
 					}
-					if slices.Contains(*res.Result.MemberuserGroup, val) {
+					if isStringListContainsCaseInsensistive(res.Result.MemberuserGroup, &val) {
 						tflog.Debug(ctx, fmt.Sprintf("[DEBUG] Read freeipa sudo user group member %s is present in results", val))
 						changedVals = append(changedVals, val)
 					}

--- a/freeipa/sudo_rule_user_membership_test.go
+++ b/freeipa/sudo_rule_user_membership_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 func TestAccFreeIPASudoRuleUserMembership_simple(t *testing.T) {
@@ -63,6 +64,85 @@ func TestAccFreeIPASudoRuleUserMembership_simple(t *testing.T) {
 					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "member_group.#", "1"),
 					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "member_group.0", "testacc-group-0"),
 				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAUser_resource(testMemberUser) + testAccFreeIPAGroup_resource(testGroup) + testAccFreeIPASudoRule_resource(testSudoRule) + testAccFreeIPASudoRuleUserMembership_resource(testSudoUserMembership) + testAccFreeIPASudoRuleUserMembership_resource(testSudoUserGrpMembership) + testAccFreeIPASudoRule_datasource(testSudoDS),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccFreeIPASudoRuleUserMembership_simple_CaseInsensitive(t *testing.T) {
+	testGroup := map[string]string{
+		"index":       "0",
+		"name":        "\"TestACC-Group-0\"",
+		"description": "\"User group test 0\"",
+	}
+	testMemberUser := map[string]string{
+		"index":     "0",
+		"login":     "\"TestACC-User-0\"",
+		"firstname": "\"Test\"",
+		"lastname":  "\"User0\"",
+	}
+	testSudoRule := map[string]string{
+		"index":       "1",
+		"name":        "\"TestACC SudoRule\"",
+		"description": "\"A sudo rule for acceptance tests\"",
+	}
+	testSudoUserMembership := map[string]string{
+		"index": "1",
+		"name":  "freeipa_sudo_rule.sudorule-1.name",
+		"user":  "freeipa_user.user-0.name",
+	}
+	testSudoUserGrpMembership := map[string]string{
+		"index": "2",
+		"name":  "freeipa_sudo_rule.sudorule-1.name",
+		"group": "freeipa_group.group-0.name",
+	}
+	testSudoDS := map[string]string{
+		"index": "1",
+		"name":  "freeipa_sudo_rule.sudorule-1.name",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAUser_resource(testMemberUser) + testAccFreeIPAGroup_resource(testGroup) + testAccFreeIPASudoRule_resource(testSudoRule) + testAccFreeIPASudoRuleUserMembership_resource(testSudoUserMembership) + testAccFreeIPASudoRuleUserMembership_resource(testSudoUserGrpMembership),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("freeipa_sudo_rule.sudorule-1", "id", "TestACC SudoRule"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule.sudorule-1", "name", "TestACC SudoRule"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule.sudorule-1", "description", "A sudo rule for acceptance tests"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule_user_membership.sudo-user-membership-1", "name", "TestACC SudoRule"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule_user_membership.sudo-user-membership-1", "user", "TestACC-User-0"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule_user_membership.sudo-user-membership-2", "name", "TestACC SudoRule"),
+					resource.TestCheckResourceAttr("freeipa_sudo_rule_user_membership.sudo-user-membership-2", "group", "TestACC-Group-0"),
+				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAUser_resource(testMemberUser) + testAccFreeIPAGroup_resource(testGroup) + testAccFreeIPASudoRule_resource(testSudoRule) + testAccFreeIPASudoRuleUserMembership_resource(testSudoUserMembership) + testAccFreeIPASudoRuleUserMembership_resource(testSudoUserGrpMembership) + testAccFreeIPASudoRule_datasource(testSudoDS),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "name", "TestACC SudoRule"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "description", "A sudo rule for acceptance tests"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "member_user.#", "1"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "member_user.0", "testacc-user-0"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "member_group.#", "1"),
+					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "member_group.0", "testacc-group-0"),
+				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAUser_resource(testMemberUser) + testAccFreeIPAGroup_resource(testGroup) + testAccFreeIPASudoRule_resource(testSudoRule) + testAccFreeIPASudoRuleUserMembership_resource(testSudoUserMembership) + testAccFreeIPASudoRuleUserMembership_resource(testSudoUserGrpMembership) + testAccFreeIPASudoRule_datasource(testSudoDS),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 		},
 	})
@@ -129,6 +209,14 @@ func TestAccFreeIPASudoRuleUserMembership_mutiple(t *testing.T) {
 					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "member_group.#", "1"),
 					resource.TestCheckResourceAttr("data.freeipa_sudo_rule.sudorule-1", "member_group.0", "testacc-group-0"),
 				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAUser_resource(testMemberUser) + testAccFreeIPAGroup_resource(testGroup) + testAccFreeIPASudoRule_resource(testSudoRule) + testAccFreeIPASudoRuleUserMembership_resource(testSudoUserMembership) + testAccFreeIPASudoRuleUserMembership_resource(testSudoUserGrpMembership) + testAccFreeIPASudoRule_datasource(testSudoDS),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 		},
 	})

--- a/freeipa/user_data_source.go
+++ b/freeipa/user_data_source.go
@@ -302,6 +302,10 @@ func (r *UserDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 		return
 	}
 
+	if res.Result.Givenname != nil {
+		data.FirstName = types.StringValue(*res.Result.Givenname)
+	}
+	data.LastName = types.StringValue(res.Result.Sn)
 	if res.Result.Cn != nil {
 		data.FullName = types.StringValue(*res.Result.Cn)
 	}

--- a/freeipa/user_data_source.go
+++ b/freeipa/user_data_source.go
@@ -93,7 +93,7 @@ func (r *UserDataSource) Schema(ctx context.Context, req datasource.SchemaReques
 				Computed:            true,
 			},
 			"name": schema.StringAttribute{
-				MarkdownDescription: "UID or login",
+				MarkdownDescription: "UID or Login\n\n	- The name must not exceed 32 characters.\n	- The name must contain only lowercase letters (a-z), digits (0-9), and the characters (. - _).\n	- The name must not start with a special character.\n	- A user and a group cannot have the same name.",
 				Required:            true,
 			},
 			"full_name": schema.StringAttribute{

--- a/freeipa/user_group_membership_resource.go
+++ b/freeipa/user_group_membership_resource.go
@@ -369,11 +369,9 @@ func (r *userGroupMembership) Read(ctx context.Context, req resource.ReadRequest
 
 	switch typeId {
 	case "g":
-		v := []string{userId}
 		if res.Result.MemberGroup != nil {
-			groups := *res.Result.MemberGroup
-			if slices.Contains(groups, v[0]) {
-				data.Group = types.StringValue(v[0])
+			if isStringListContainsCaseInsensistive(res.Result.MemberGroup, &userId) {
+				data.Group = types.StringValue(userId)
 			} else {
 				data.Group = types.StringValue("")
 				data.Id = types.StringValue("")
@@ -383,11 +381,9 @@ func (r *userGroupMembership) Read(ctx context.Context, req resource.ReadRequest
 			return
 		}
 	case "u":
-		v := []string{userId}
 		if res.Result.MemberUser != nil {
-			users := *res.Result.MemberUser
-			if slices.Contains(users, v[0]) {
-				data.User = types.StringValue(v[0])
+			if isStringListContainsCaseInsensistive(res.Result.MemberUser, &userId) {
+				data.User = types.StringValue(userId)
 			} else {
 				data.User = types.StringValue("")
 				data.Id = types.StringValue("")
@@ -420,7 +416,7 @@ func (r *userGroupMembership) Read(ctx context.Context, req resource.ReadRequest
 				if err != nil {
 					tflog.Debug(ctx, fmt.Sprintf("[DEBUG] Read freeipa group member users failed with error %s", err))
 				}
-				if slices.Contains(*res.Result.MemberUser, val) {
+				if isStringListContainsCaseInsensistive(res.Result.MemberUser, &val) {
 					tflog.Debug(ctx, fmt.Sprintf("[DEBUG] Read freeipa group member users %s is present in results", val))
 					changedVals = append(changedVals, val)
 				}
@@ -439,7 +435,7 @@ func (r *userGroupMembership) Read(ctx context.Context, req resource.ReadRequest
 				if err != nil {
 					tflog.Debug(ctx, fmt.Sprintf("[DEBUG] Read freeipa group member groups failed with error %s", err))
 				}
-				if slices.Contains(*res.Result.MemberGroup, val) {
+				if isStringListContainsCaseInsensistive(res.Result.MemberGroup, &val) {
 					tflog.Debug(ctx, fmt.Sprintf("[DEBUG] Read freeipa group member groups %s is present in results", val))
 					changedVals = append(changedVals, val)
 				}

--- a/freeipa/user_group_membership_test.go
+++ b/freeipa/user_group_membership_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 func TestAccFreeIPAUserGroupMembership_posix(t *testing.T) {
@@ -51,6 +52,72 @@ func TestAccFreeIPAUserGroupMembership_posix(t *testing.T) {
 					resource.TestCheckResourceAttr("freeipa_user_group_membership.membership-1", "name", "testacc-group"),
 					resource.TestCheckResourceAttr("freeipa_user_group_membership.membership-1", "group", "testacc-groupmember"),
 				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAGroup_resource(testGroup) + testAccFreeIPAGroup_resource(testMemberGroup) + testAccFreeIPAUser_resource(testMemberUser) + testAccFreeIPAUserGroupMembership_resource(testMembershipUser) + testAccFreeIPAUserGroupMembership_resource(testMembershipGroup),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccFreeIPAUserGroupMembership_simple_posix_CaseInsensitive(t *testing.T) {
+	testGroup := map[string]string{
+		"index":       "0",
+		"name":        "\"TestACC-Group\"",
+		"description": "\"User group test\"",
+	}
+	testMemberUser := map[string]string{
+		"index":     "0",
+		"login":     "\"TestACC-User\"",
+		"firstname": "\"Test\"",
+		"lastname":  "\"User\"",
+	}
+	testMemberGroup := map[string]string{
+		"index":       "1",
+		"name":        "\"TestACC-GroupMember\"",
+		"description": "\"User group test - member of testgroup\"",
+	}
+	testMembershipUser := map[string]string{
+		"index": "0",
+		"name":  "freeipa_group.group-0.name",
+		"user":  "freeipa_user.user-0.name",
+	}
+	testMembershipGroup := map[string]string{
+		"index": "1",
+		"name":  "freeipa_group.group-0.name",
+		"group": "freeipa_group.group-1.name",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAGroup_resource(testGroup) + testAccFreeIPAGroup_resource(testMemberGroup) + testAccFreeIPAUser_resource(testMemberUser) + testAccFreeIPAUserGroupMembership_resource(testMembershipUser) + testAccFreeIPAUserGroupMembership_resource(testMembershipGroup),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("freeipa_group.group-0", "description", "User group test"),
+					resource.TestCheckResourceAttr("freeipa_group.group-0", "name", "TestACC-Group"),
+					resource.TestCheckResourceAttr("freeipa_group.group-1", "description", "User group test - member of testgroup"),
+					resource.TestCheckResourceAttr("freeipa_group.group-1", "name", "TestACC-GroupMember"),
+					resource.TestCheckResourceAttr("freeipa_user.user-0", "name", "TestACC-User"),
+					resource.TestCheckResourceAttr("freeipa_user_group_membership.membership-0", "name", "TestACC-Group"),
+					resource.TestCheckResourceAttr("freeipa_user_group_membership.membership-0", "user", "TestACC-User"),
+					resource.TestCheckResourceAttr("freeipa_user_group_membership.membership-1", "name", "TestACC-Group"),
+					resource.TestCheckResourceAttr("freeipa_user_group_membership.membership-1", "group", "TestACC-GroupMember"),
+				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAGroup_resource(testGroup) + testAccFreeIPAGroup_resource(testMemberGroup) + testAccFreeIPAUser_resource(testMemberUser) + testAccFreeIPAUserGroupMembership_resource(testMembershipUser) + testAccFreeIPAUserGroupMembership_resource(testMembershipGroup),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 		},
 	})
@@ -130,6 +197,14 @@ func TestAccFreeIPAUserGroupMembership_multiple_posix(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAGroup_resource(testGroup1) + testAccFreeIPAGroup_resource(testGroup2) + testAccFreeIPAGroup_resource(testGroup3) + testAccFreeIPAUser_resource(testMemberUser1) + testAccFreeIPAUser_resource(testMemberUser2) + testAccFreeIPAUserGroupMembership_resource(testMembershipGroups1) + testAccFreeIPAUserGroupMembership_resource(testMembershipUsers1),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			{
 				Config: testAccFreeIPAProvider() + testAccFreeIPAGroup_resource(testGroup1) + testAccFreeIPAGroup_resource(testGroup2) + testAccFreeIPAGroup_resource(testGroup3) + testAccFreeIPAUser_resource(testMemberUser1) + testAccFreeIPAUser_resource(testMemberUser2) + testAccFreeIPAUserGroupMembership_resource(testMembershipGroups2) + testAccFreeIPAUserGroupMembership_resource(testMembershipUsers2),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("freeipa_group.group-0", "description", "User group test 0"),
@@ -144,6 +219,75 @@ func TestAccFreeIPAUserGroupMembership_multiple_posix(t *testing.T) {
 					resource.TestCheckResourceAttr("freeipa_user_group_membership.membership-1", "users.0", "testacc-user-0"),
 					resource.TestCheckResourceAttr("freeipa_user_group_membership.membership-1", "users.1", "testacc-user-1"),
 				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAGroup_resource(testGroup1) + testAccFreeIPAGroup_resource(testGroup2) + testAccFreeIPAGroup_resource(testGroup3) + testAccFreeIPAUser_resource(testMemberUser1) + testAccFreeIPAUser_resource(testMemberUser2) + testAccFreeIPAUserGroupMembership_resource(testMembershipGroups2) + testAccFreeIPAUserGroupMembership_resource(testMembershipUsers2),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccFreeIPAUserGroupMembership_multiple_posix_CaseInsensitive(t *testing.T) {
+	testGroup1 := map[string]string{
+		"index":       "0",
+		"name":        "\"TestACC-Group-0\"",
+		"description": "\"User group test 0\"",
+	}
+	testGroup2 := map[string]string{
+		"index":       "1",
+		"name":        "\"TestACC-Group-1\"",
+		"description": "\"User group test 1\"",
+	}
+	testMemberUser1 := map[string]string{
+		"index":     "0",
+		"login":     "\"TestACC-User-0\"",
+		"firstname": "\"Test\"",
+		"lastname":  "\"User0\"",
+	}
+	testMembershipGroups1 := map[string]string{
+		"index":       "0",
+		"name":        "freeipa_group.group-0.name",
+		"description": "\"User group test - member of testgroup\"",
+		"groups":      "[freeipa_group.group-1.name]",
+		"identifier":  "\"groups\"",
+	}
+	testMembershipUsers1 := map[string]string{
+		"index":      "1",
+		"name":       "freeipa_group.group-0.name",
+		"users":      "[freeipa_user.user-0.name]",
+		"identifier": "\"users\"",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAGroup_resource(testGroup1) + testAccFreeIPAGroup_resource(testGroup2) + testAccFreeIPAUser_resource(testMemberUser1) + testAccFreeIPAUserGroupMembership_resource(testMembershipGroups1) + testAccFreeIPAUserGroupMembership_resource(testMembershipUsers1),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("freeipa_group.group-0", "description", "User group test 0"),
+					resource.TestCheckResourceAttr("freeipa_group.group-0", "name", "TestACC-Group-0"),
+					resource.TestCheckResourceAttr("freeipa_user.user-0", "name", "TestACC-User-0"),
+					resource.TestCheckResourceAttr("freeipa_user_group_membership.membership-0", "name", "TestACC-Group-0"),
+					resource.TestCheckResourceAttr("freeipa_user_group_membership.membership-0", "groups.#", "1"),
+					resource.TestCheckResourceAttr("freeipa_user_group_membership.membership-0", "groups.0", "TestACC-Group-1"),
+					resource.TestCheckResourceAttr("freeipa_user_group_membership.membership-1", "name", "TestACC-Group-0"),
+					resource.TestCheckResourceAttr("freeipa_user_group_membership.membership-1", "users.#", "1"),
+					resource.TestCheckResourceAttr("freeipa_user_group_membership.membership-1", "users.0", "TestACC-User-0"),
+				),
+			},
+			{
+				Config: testAccFreeIPAProvider() + testAccFreeIPAGroup_resource(testGroup1) + testAccFreeIPAGroup_resource(testGroup2) + testAccFreeIPAUser_resource(testMemberUser1) + testAccFreeIPAUserGroupMembership_resource(testMembershipGroups1) + testAccFreeIPAUserGroupMembership_resource(testMembershipUsers1),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 		},
 	})

--- a/freeipa/user_resource.go
+++ b/freeipa/user_resource.go
@@ -437,7 +437,7 @@ func (r *UserResource) Create(ctx context.Context, req resource.CreateRequest, r
 	}
 	tflog.Debug(ctx, fmt.Sprintf("[DEBUG] Create freeipa user %s returns %s", data.UID.String(), res.String()))
 
-	data.Id = types.StringValue(data.UID.ValueString())
+	data.Id = types.StringValue(res.Result.UID)
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/freeipa/user_resource.go
+++ b/freeipa/user_resource.go
@@ -107,7 +107,7 @@ func (r *UserResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 				},
 			},
 			"name": schema.StringAttribute{
-				MarkdownDescription: "UID or login",
+				MarkdownDescription: "UID or Login\n\n	- The name must not exceed 32 characters.\n	- The name must contain only lowercase letters (a-z), digits (0-9), and the characters (. - _).\n	- The name must not start with a special character.\n	- A user and a group cannot have the same name.",
 				Required:            true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),

--- a/freeipa/utils.go
+++ b/freeipa/utils.go
@@ -23,3 +23,12 @@ func encodeSlash(str string) string {
 func decodeSlash(str string) string {
 	return strings.ReplaceAll(str, "%2F", string('/'))
 }
+
+func isStringListContainsCaseInsensistive(strList *[]string, str *string) bool {
+	for _, s := range *strList {
+		if strings.EqualFold(s, *str) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION

Fixes: #58 
I have implemented a function that checks if a string is present in a list of strings without caring for the case. This is used when getting the actual value from freeipa and matching with the expected state even if the case has been changed by freeipa.
I also added idempotency tests for each resource with additional tests using capitalized names for resources where the are case insensitive.

No change in attributes or features.

Should I add a best practice in README.md for using only lowercase values for attributes?