### PR TITLE
fix: cname dns records are not properly imported

### DIFF
--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
     freeipa = {
-      version = "0.1.1"
-      source  = "[Terraform registry provider path]"
+      version = "5.1.0"
+      source  = "rework-space-com/freeipa"
     }
   }
 }

--- a/examples/resources/freeipa_dns_record/import.sh
+++ b/examples/resources/freeipa_dns_record/import.sh
@@ -2,8 +2,8 @@
 # or without the optional set_identifier : <name>;<zone_name>;<type>
 
 import {
-    to = freeipa_dns_record.txtrecord
-    id = "_kerberos;testimport.ipatest.lan;TXT;krbtxt"
+  to = freeipa_dns_record.txtrecord
+  id = "_kerberos;testimport.ipatest.lan;TXT;krbtxt"
 }
 
 resource "freeipa_dns_record" "txtrecord" {
@@ -15,8 +15,8 @@ resource "freeipa_dns_record" "txtrecord" {
 }
 
 import {
-    to = freeipa_dns_record.arecord
-    id = "test;testimport.ipatest.lan;A"
+  to = freeipa_dns_record.arecord
+  id = "test;testimport.ipatest.lan;A"
 }
 
 resource "freeipa_dns_record" "arecord" {
@@ -27,8 +27,8 @@ resource "freeipa_dns_record" "arecord" {
 }
 
 import {
-    to = freeipa_dns_record.ptrrecord
-    id = "2;2.27.172.in-addr.arpa;PTR"
+  to = freeipa_dns_record.ptrrecord
+  id = "2;2.27.172.in-addr.arpa;PTR"
 }
 
 resource "freeipa_dns_record" "ptrrecord" {

--- a/examples/resources/freeipa_dns_zone/import.sh
+++ b/examples/resources/freeipa_dns_zone/import.sh
@@ -2,24 +2,24 @@
 # The import id attribute must be the undotted fqdn of the zone to import
 
 import {
-    to = freeipa_dns_zone.testzone
-    id = "testimport.ipatest.lan"
+  to = freeipa_dns_zone.testzone
+  id = "testimport.ipatest.lan"
 }
 
 resource "freeipa_dns_zone" "testzone" {
-  zone_name          = "testimport.ipatest.lan"
+  zone_name = "testimport.ipatest.lan"
 }
 
 # reverse zone
 # The import id attribute must be the undotted fqdn of the zone to import
 
 import {
-    to = freeipa_dns_zone.reversetestzone
-    id = "2.27.172.in-addr.arpa"
+  to = freeipa_dns_zone.reversetestzone
+  id = "2.27.172.in-addr.arpa"
 }
 
 resource "freeipa_dns_zone" "reversetestzone" {
-  zone_name          = "2.27.172.in-addr.arpa"
+  zone_name = "2.27.172.in-addr.arpa"
 }
 
 # note that the is_reverse_zone must not be defined, this is only useful for creation

--- a/examples/resources/freeipa_group/import.sh
+++ b/examples/resources/freeipa_group/import.sh
@@ -2,35 +2,35 @@
 
 # for posix groups, only the name needs to be defined in the resource statement.
 import {
-    to = freeipa_group.group-posix
-    id = "testposix"
+  to = freeipa_group.group-posix
+  id = "testposix"
 }
 
 resource "freeipa_group" "group-posix" {
-    name = "testposix"
+  name = "testposix"
 }
 
 # for external groups, the external attribute must also be defined in the resource statement.
 import {
-    to = freeipa_group.group-external
-    id = "testexternal"
+  to = freeipa_group.group-external
+  id = "testexternal"
 }
 
 resource "freeipa_group" "group-external" {
-    name     = "testexternal"
-    external = true
+  name     = "testexternal"
+  external = true
 }
 
 
 # for non posix groups, the nonposix attribute must also be defined in the resource statement.
 import {
-    to = freeipa_group.group-nonposix
-    id = "testnonposix"
+  to = freeipa_group.group-nonposix
+  id = "testnonposix"
 }
 
 resource "freeipa_group" "group-nonposix" {
-    name     = "testnonposix"
-    nonposix = true
+  name     = "testnonposix"
+  nonposix = true
 }
 
 # note that nonposix and external are two mutually exclusive attributes.

--- a/examples/resources/freeipa_hbac_policy/import.sh
+++ b/examples/resources/freeipa_hbac_policy/import.sh
@@ -1,10 +1,10 @@
 # The import id must be exactly the same as the name of the HBAC policy.
 
 import {
-    to = freeipa_hbac_policy.testhbac
-    id = "testhbac"
+  to = freeipa_hbac_policy.testhbac
+  id = "testhbac"
 }
 
 resource "freeipa_hbac_policy" "testhbac" {
-    name = "testhbac"
+  name = "testhbac"
 }

--- a/examples/resources/freeipa_host/import.sh
+++ b/examples/resources/freeipa_host/import.sh
@@ -1,10 +1,10 @@
 # The import id must be exactly the same as the name of the host, which must be the fqdn of the host.
 
 import {
-    to = freeipa_host.testhost
-    id = "testhost.ipatest.lan"
+  to = freeipa_host.testhost
+  id = "testhost.ipatest.lan"
 }
 
 resource "freeipa_host" "testhost" {
-    name = "testhost.ipatest.lan"
+  name = "testhost.ipatest.lan"
 }

--- a/examples/resources/freeipa_hostgroup/import.sh
+++ b/examples/resources/freeipa_hostgroup/import.sh
@@ -1,10 +1,10 @@
 # The import id must be exactly the same as the name of the host group.
 
 import {
-    to = freeipa_hostgroup.testhostgroup
-    id = "testhostgroup"
+  to = freeipa_hostgroup.testhostgroup
+  id = "testhostgroup"
 }
 
 resource "freeipa_hostgroup" "testhostgroup" {
-    name = "testhostgroup"
+  name = "testhostgroup"
 }

--- a/examples/resources/freeipa_sudo_cmd/import.sh
+++ b/examples/resources/freeipa_sudo_cmd/import.sh
@@ -1,10 +1,10 @@
 # The import id must be exactly the same as the sudo command.
 
 import {
-    to = freeipa_sudo_cmd.testsudocmd
-    id = "/bin/bash"
+  to = freeipa_sudo_cmd.testsudocmd
+  id = "/bin/bash"
 }
 
 resource "freeipa_sudo_cmd" "testsudocmd" {
-    name = "/bin/bash"
+  name = "/bin/bash"
 }

--- a/examples/resources/freeipa_sudo_cmdgroup/import.sh
+++ b/examples/resources/freeipa_sudo_cmdgroup/import.sh
@@ -1,11 +1,11 @@
 # The import id must be exactly the same as the name of the sudo command group.
 
 import {
-    to = freeipa_sudo_cmdgroup.testsudocmdgrp
-    id = "testsudocmdgrp"
+  to = freeipa_sudo_cmdgroup.testsudocmdgrp
+  id = "testsudocmdgrp"
 }
 
 
 resource "freeipa_sudo_cmdgroup" "testsudocmdgrp" {
-    name = "testsudocmdgrp"
+  name = "testsudocmdgrp"
 }

--- a/examples/resources/freeipa_sudo_rule/import.sh
+++ b/examples/resources/freeipa_sudo_rule/import.sh
@@ -1,8 +1,8 @@
 import {
-    to = freeipa_sudo_rule.testsudorule
-    id = "testsudorule"
+  to = freeipa_sudo_rule.testsudorule
+  id = "testsudorule"
 }
 
 resource "freeipa_sudo_rule" "testsudorule" {
-    name = "testsudorule"
+  name = "testsudorule"
 }

--- a/examples/resources/freeipa_user/import.sh
+++ b/examples/resources/freeipa_user/import.sh
@@ -6,12 +6,12 @@
 # - `last_name`
 
 import {
-    to = freeipa_user.testuser
-    id = "testuser"
+  to = freeipa_user.testuser
+  id = "testuser"
 }
 
 resource "freeipa_user" "testuser" {
-    name       = "testuser"
-    first_name = "Test"
-    last_name  = "User"
+  name       = "testuser"
+  first_name = "Test"
+  last_name  = "User"
 }

--- a/freeipa/dns_record_resource.go
+++ b/freeipa/dns_record_resource.go
@@ -20,11 +20,13 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	ipa "github.com/infra-monkey/go-freeipa/freeipa"
@@ -91,10 +93,13 @@ func (r *DNSRecordResource) Schema(ctx context.Context, req resource.SchemaReque
 				},
 			},
 			"type": schema.StringAttribute{
-				MarkdownDescription: "The record type (A, AAAA, CNAME, MX, PTR, SRV, TXT, SSHP)",
+				MarkdownDescription: "The record type (A, AAAA, CNAME, MX, PTR, SRV, TXT, SSHFP)",
 				Required:            true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{
+					stringvalidator.OneOf("A", "AAAA", "CNAME", "MX", "PTR", "SRV", "TXT", "SSHFP"),
 				},
 			},
 			"records": schema.SetAttribute{
@@ -265,6 +270,10 @@ func (r *DNSRecordResource) Read(ctx context.Context, req resource.ReadRequest, 
 	case "AAAA":
 		if res.Result.Aaaarecord != nil {
 			data.Records, _ = types.SetValueFrom(ctx, types.StringType, res.Result.Aaaarecord)
+		}
+	case "CNAME":
+		if res.Result.Cnamerecord != nil {
+			data.Records, _ = types.SetValueFrom(ctx, types.StringType, res.Result.Cnamerecord)
 		}
 	case "MX":
 		if res.Result.Mxrecord != nil {
@@ -487,6 +496,10 @@ func (r *DNSRecordResource) ImportState(ctx context.Context, req resource.Import
 	case "AAAA":
 		if res.Result.Aaaarecord != nil {
 			resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("records"), *res.Result.Aaaarecord)...)
+		}
+	case "CNAME":
+		if res.Result.Cnamerecord != nil {
+			resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("records"), *res.Result.Cnamerecord)...)
 		}
 	case "MX":
 		if res.Result.Mxrecord != nil {


### PR DESCRIPTION
Current code doesn't handle cname for import.
It results in correct state and object in freeipa but through an import + update 

This fix implements a proper import with no action on freeipa.