### PR TITLE
doc: fix doc template for missing description

### DIFF
--- a/docs/data-sources/dns_record.md
+++ b/docs/data-sources/dns_record.md
@@ -1,7 +1,7 @@
 ---
 page_title: "freeipa_dns_record Data Source - freeipa"
 description: |-
-FreeIPA DNS Record data source
+  FreeIPA DNS Record data source
 ---
 
 # freeipa_dns_record (Data Source)

--- a/docs/data-sources/dns_zone.md
+++ b/docs/data-sources/dns_zone.md
@@ -1,7 +1,7 @@
 ---
 page_title: "freeipa_dns_zone Data Source - freeipa"
 description: |-
-FreeIPA DNS Zone resource
+  FreeIPA DNS Zone resource
 ---
 
 # freeipa_dns_zone (Data Source)

--- a/docs/data-sources/group.md
+++ b/docs/data-sources/group.md
@@ -1,7 +1,7 @@
 ---
 page_title: "freeipa_group Data Source - freeipa"
 description: |-
-FreeIPA User Group data source
+  FreeIPA User Group data source
 ---
 
 # freeipa_group (Data Source)

--- a/docs/data-sources/hbac_policy.md
+++ b/docs/data-sources/hbac_policy.md
@@ -1,7 +1,7 @@
 ---
 page_title: "freeipa_hbac_policy Data Source - freeipa"
 description: |-
-FreeIPA User hbac policy data source
+  FreeIPA User hbac policy data source
 ---
 
 # freeipa_hbac_policy (Data Source)

--- a/docs/data-sources/host.md
+++ b/docs/data-sources/host.md
@@ -1,7 +1,7 @@
 ---
 page_title: "freeipa_host Data Source - freeipa"
 description: |-
-FreeIPA Host data source
+  FreeIPA Host data source
 ---
 
 # freeipa_host (Data Source)

--- a/docs/data-sources/hostgroup.md
+++ b/docs/data-sources/hostgroup.md
@@ -1,7 +1,7 @@
 ---
 page_title: "freeipa_hostgroup Data Source - freeipa"
 description: |-
-FreeIPA User Group data source
+  FreeIPA Host Group data source
 ---
 
 # freeipa_hostgroup (Data Source)

--- a/docs/data-sources/sudo_cmdgroup.md
+++ b/docs/data-sources/sudo_cmdgroup.md
@@ -1,7 +1,7 @@
 ---
 page_title: "freeipa_sudo_cmdgroup Data Source - freeipa"
 description: |-
-FreeIPA User sudo command group data source
+  FreeIPA Sudo command group data source
 ---
 
 # freeipa_sudo_cmdgroup (Data Source)

--- a/docs/data-sources/sudo_rule.md
+++ b/docs/data-sources/sudo_rule.md
@@ -1,7 +1,7 @@
 ---
 page_title: "freeipa_sudo_rule Data Source - freeipa"
 description: |-
-FreeIPA User sudo rule data source
+  FreeIPA Sudo rule data source
 ---
 
 # freeipa_sudo_rule (Data Source)

--- a/docs/data-sources/user.md
+++ b/docs/data-sources/user.md
@@ -1,7 +1,7 @@
 ---
 page_title: "freeipa_user Data Source - freeipa"
 description: |-
-FreeIPA User data source
+  FreeIPA User data source
 ---
 
 # freeipa_user (Data Source)

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,8 +12,8 @@ description: |-
 terraform {
   required_providers {
     freeipa = {
-      version = "0.1.1"
-      source  = "[Terraform registry provider path]"
+      version = "5.1.0"
+      source  = "rework-space-com/freeipa"
     }
   }
 }

--- a/docs/resources/automemberadd.md
+++ b/docs/resources/automemberadd.md
@@ -1,7 +1,7 @@
 ---
 page_title: "freeipa_automemberadd Resource - freeipa"
 description: |-
-FreeIPA Automember resource
+  FreeIPA Automember resource
 ---
 
 # freeipa_automemberadd (Resource)

--- a/docs/resources/automemberadd_condition.md
+++ b/docs/resources/automemberadd_condition.md
@@ -1,7 +1,7 @@
 ---
 page_title: "freeipa_automemberadd_condition Resource - freeipa"
 description: |-
-FreeIPA Automember conditionresource
+  FreeIPA Automember condition resource
 ---
 
 # freeipa_automemberadd_condition (Resource)

--- a/docs/resources/dns_record.md
+++ b/docs/resources/dns_record.md
@@ -1,7 +1,7 @@
 ---
 page_title: "freeipa_dns_record Resource - freeipa"
 description: |-
-FreeIPA DNS Record resource
+  FreeIPA DNS Record resource
 ---
 
 # freeipa_dns_record (Resource)
@@ -40,8 +40,8 @@ resource "freeipa_dns_record" "record-7" {
 # or without the optional set_identifier : <name>;<zone_name>;<type>
 
 import {
-    to = freeipa_dns_record.txtrecord
-    id = "_kerberos;testimport.ipatest.lan;TXT;krbtxt"
+  to = freeipa_dns_record.txtrecord
+  id = "_kerberos;testimport.ipatest.lan;TXT;krbtxt"
 }
 
 resource "freeipa_dns_record" "txtrecord" {
@@ -53,8 +53,8 @@ resource "freeipa_dns_record" "txtrecord" {
 }
 
 import {
-    to = freeipa_dns_record.arecord
-    id = "test;testimport.ipatest.lan;A"
+  to = freeipa_dns_record.arecord
+  id = "test;testimport.ipatest.lan;A"
 }
 
 resource "freeipa_dns_record" "arecord" {
@@ -65,8 +65,8 @@ resource "freeipa_dns_record" "arecord" {
 }
 
 import {
-    to = freeipa_dns_record.ptrrecord
-    id = "2;2.27.172.in-addr.arpa;PTR"
+  to = freeipa_dns_record.ptrrecord
+  id = "2;2.27.172.in-addr.arpa;PTR"
 }
 
 resource "freeipa_dns_record" "ptrrecord" {
@@ -85,7 +85,7 @@ resource "freeipa_dns_record" "ptrrecord" {
 
 - `name` (String) Record name
 - `records` (Set of String) A string list of records
-- `type` (String) The record type (A, AAAA, CNAME, MX, PTR, SRV, TXT, SSHP)
+- `type` (String) The record type (A, AAAA, CNAME, MX, PTR, SRV, TXT, SSHFP)
 - `zone_name` (String) Zone name (FQDN)
 
 ### Optional

--- a/docs/resources/dns_zone.md
+++ b/docs/resources/dns_zone.md
@@ -1,7 +1,7 @@
 ---
 page_title: "freeipa_dns_zone Resource - freeipa"
 description: |-
-FreeIPA DNS Zone resource
+  FreeIPA DNS Zone resource
 ---
 
 # freeipa_dns_zone (Resource)
@@ -27,24 +27,24 @@ resource "freeipa_dns_zone" "dns_zone-2" {
 # The import id attribute must be the undotted fqdn of the zone to import
 
 import {
-    to = freeipa_dns_zone.testzone
-    id = "testimport.ipatest.lan"
+  to = freeipa_dns_zone.testzone
+  id = "testimport.ipatest.lan"
 }
 
 resource "freeipa_dns_zone" "testzone" {
-  zone_name          = "testimport.ipatest.lan"
+  zone_name = "testimport.ipatest.lan"
 }
 
 # reverse zone
 # The import id attribute must be the undotted fqdn of the zone to import
 
 import {
-    to = freeipa_dns_zone.reversetestzone
-    id = "2.27.172.in-addr.arpa"
+  to = freeipa_dns_zone.reversetestzone
+  id = "2.27.172.in-addr.arpa"
 }
 
 resource "freeipa_dns_zone" "reversetestzone" {
-  zone_name          = "2.27.172.in-addr.arpa"
+  zone_name = "2.27.172.in-addr.arpa"
 }
 
 # note that the is_reverse_zone must not be defined, this is only useful for creation

--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -1,7 +1,7 @@
 ---
 page_title: "freeipa_group Resource - freeipa"
 description: |-
-FreeIPA User Group resource
+  FreeIPA User Group resource
 ---
 
 # freeipa_group (Resource)
@@ -39,35 +39,35 @@ resource "freeipa_group" "group-external" {
 
 # for posix groups, only the name needs to be defined in the resource statement.
 import {
-    to = freeipa_group.group-posix
-    id = "testposix"
+  to = freeipa_group.group-posix
+  id = "testposix"
 }
 
 resource "freeipa_group" "group-posix" {
-    name = "testposix"
+  name = "testposix"
 }
 
 # for external groups, the external attribute must also be defined in the resource statement.
 import {
-    to = freeipa_group.group-external
-    id = "testexternal"
+  to = freeipa_group.group-external
+  id = "testexternal"
 }
 
 resource "freeipa_group" "group-external" {
-    name     = "testexternal"
-    external = true
+  name     = "testexternal"
+  external = true
 }
 
 
 # for non posix groups, the nonposix attribute must also be defined in the resource statement.
 import {
-    to = freeipa_group.group-nonposix
-    id = "testnonposix"
+  to = freeipa_group.group-nonposix
+  id = "testnonposix"
 }
 
 resource "freeipa_group" "group-nonposix" {
-    name     = "testnonposix"
-    nonposix = true
+  name     = "testnonposix"
+  nonposix = true
 }
 
 # note that nonposix and external are two mutually exclusive attributes.

--- a/docs/resources/hbac_policy.md
+++ b/docs/resources/hbac_policy.md
@@ -1,7 +1,7 @@
 ---
 page_title: "freeipa_hbac_policy Resource - freeipa"
 description: |-
-FreeIPA HBAC policy resource
+  FreeIPA HBAC policy resource
 ---
 
 # freeipa_hbac_policy (Resource)
@@ -28,12 +28,12 @@ resource "freeipa_hbac_policy" "hbac-0" {
 # The import id must be exactly the same as the name of the HBAC policy.
 
 import {
-    to = freeipa_hbac_policy.testhbac
-    id = "testhbac"
+  to = freeipa_hbac_policy.testhbac
+  id = "testhbac"
 }
 
 resource "freeipa_hbac_policy" "testhbac" {
-    name = "testhbac"
+  name = "testhbac"
 }
 ```
 

--- a/docs/resources/hbac_policy_host_membership.md
+++ b/docs/resources/hbac_policy_host_membership.md
@@ -1,7 +1,7 @@
 ---
 page_title: "freeipa_hbac_policy_host_membership Resource - freeipa"
 description: |-
-FreeIPA HBAC policy host membership resource
+  FreeIPA HBAC policy host membership resource
 ---
 
 # freeipa_hbac_policy_host_membership (Resource)

--- a/docs/resources/hbac_policy_service_membership.md
+++ b/docs/resources/hbac_policy_service_membership.md
@@ -1,7 +1,7 @@
 ---
 page_title: "freeipa_hbac_policy_service_membership Resource - freeipa"
 description: |-
-FreeIPA HBAC policy service membership resource
+  FreeIPA HBAC policy service membership resource
 ---
 
 # freeipa_hbac_policy_service_membership (Resource)

--- a/docs/resources/hbac_policy_user_membership.md
+++ b/docs/resources/hbac_policy_user_membership.md
@@ -1,7 +1,7 @@
 ---
 page_title: "freeipa_hbac_policy_user_membership Resource - freeipa"
 description: |-
-FreeIPA HBAC policy host membership resource
+  FreeIPA HBAC policy host membership resource
 ---
 
 # freeipa_hbac_policy_user_membership (Resource)

--- a/docs/resources/host.md
+++ b/docs/resources/host.md
@@ -1,7 +1,7 @@
 ---
 page_title: "freeipa_host Resource - freeipa"
 description: |-
-FreeIPA User resource
+  FreeIPA Host resource
 ---
 
 # freeipa_host (Resource)
@@ -27,12 +27,12 @@ resource "freeipa_host" "host-1" {
 # The import id must be exactly the same as the name of the host, which must be the fqdn of the host.
 
 import {
-    to = freeipa_host.testhost
-    id = "testhost.ipatest.lan"
+  to = freeipa_host.testhost
+  id = "testhost.ipatest.lan"
 }
 
 resource "freeipa_host" "testhost" {
-    name = "testhost.ipatest.lan"
+  name = "testhost.ipatest.lan"
 }
 ```
 

--- a/docs/resources/host_hostgroup_membership.md
+++ b/docs/resources/host_hostgroup_membership.md
@@ -1,7 +1,7 @@
 ---
 page_title: "freeipa_host_hostgroup_membership Resource - freeipa"
 description: |-
-FreeIPA User Group Membership resource
+  FreeIPA User Group Membership resource
 ---
 
 # freeipa_host_hostgroup_membership (Resource)

--- a/docs/resources/hostgroup.md
+++ b/docs/resources/hostgroup.md
@@ -1,7 +1,7 @@
 ---
 page_title: "freeipa_hostgroup Resource - freeipa"
 description: |-
-FreeIPA User Group resource
+  FreeIPA Host Group resource
 ---
 
 # freeipa_hostgroup (Resource)
@@ -25,12 +25,12 @@ resource "freeipa_hostgroup" "hostgroup-1" {
 # The import id must be exactly the same as the name of the host group.
 
 import {
-    to = freeipa_hostgroup.testhostgroup
-    id = "testhostgroup"
+  to = freeipa_hostgroup.testhostgroup
+  id = "testhostgroup"
 }
 
 resource "freeipa_hostgroup" "testhostgroup" {
-    name = "testhostgroup"
+  name = "testhostgroup"
 }
 ```
 

--- a/docs/resources/sudo_cmd.md
+++ b/docs/resources/sudo_cmd.md
@@ -1,7 +1,7 @@
 ---
 page_title: "freeipa_sudo_cmd Resource - freeipa"
 description: |-
-FreeIPA Sudo command resource
+  FreeIPA Sudo command resource
 ---
 
 # freeipa_sudo_cmd (Resource)
@@ -25,12 +25,12 @@ resource "freeipa_sudo_cmd" "bash" {
 # The import id must be exactly the same as the sudo command.
 
 import {
-    to = freeipa_sudo_cmd.testsudocmd
-    id = "/bin/bash"
+  to = freeipa_sudo_cmd.testsudocmd
+  id = "/bin/bash"
 }
 
 resource "freeipa_sudo_cmd" "testsudocmd" {
-    name = "/bin/bash"
+  name = "/bin/bash"
 }
 ```
 

--- a/docs/resources/sudo_cmdgroup.md
+++ b/docs/resources/sudo_cmdgroup.md
@@ -1,7 +1,7 @@
 ---
 page_title: "freeipa_sudo_cmdgroup Resource - freeipa"
 description: |-
-FreeIPA Sudo command group resource
+  FreeIPA Sudo command group resource
 ---
 
 # freeipa_sudo_cmdgroup (Resource)
@@ -25,13 +25,13 @@ resource "freeipa_sudo_cmdgroup" "service_management" {
 # The import id must be exactly the same as the name of the sudo command group.
 
 import {
-    to = freeipa_sudo_cmdgroup.testsudocmdgrp
-    id = "testsudocmdgrp"
+  to = freeipa_sudo_cmdgroup.testsudocmdgrp
+  id = "testsudocmdgrp"
 }
 
 
 resource "freeipa_sudo_cmdgroup" "testsudocmdgrp" {
-    name = "testsudocmdgrp"
+  name = "testsudocmdgrp"
 }
 ```
 

--- a/docs/resources/sudo_cmdgroup_membership.md
+++ b/docs/resources/sudo_cmdgroup_membership.md
@@ -1,7 +1,7 @@
 ---
 page_title: "freeipa_sudo_cmdgroup_membership Resource - freeipa"
 description: |-
-FreeIPA Sudo command group membership resource
+  FreeIPA Sudo command group membership resource
 ---
 
 # freeipa_sudo_cmdgroup_membership (Resource)

--- a/docs/resources/sudo_rule.md
+++ b/docs/resources/sudo_rule.md
@@ -1,7 +1,7 @@
 ---
 page_title: "freeipa_sudo_rule Resource - freeipa"
 description: |-
-FreeIPA Sudo rule resource
+  FreeIPA Sudo rule resource
 ---
 
 # freeipa_sudo_rule (Resource)
@@ -23,12 +23,12 @@ resource "freeipa_sudo_rule" "sysadmins" {
 
 ```terraform
 import {
-    to = freeipa_sudo_rule.testsudorule
-    id = "testsudorule"
+  to = freeipa_sudo_rule.testsudorule
+  id = "testsudorule"
 }
 
 resource "freeipa_sudo_rule" "testsudorule" {
-    name = "testsudorule"
+  name = "testsudorule"
 }
 ```
 

--- a/docs/resources/sudo_rule_allowcmd_membership.md
+++ b/docs/resources/sudo_rule_allowcmd_membership.md
@@ -1,7 +1,7 @@
 ---
 page_title: "freeipa_sudo_rule_allowcmd_membership Resource - freeipa"
 description: |-
-FreeIPA Sudo rule allow command membership resource
+  FreeIPA Sudo rule allow command membership resource
 ---
 
 # freeipa_sudo_rule_allowcmd_membership (Resource)

--- a/docs/resources/sudo_rule_denycmd_membership.md
+++ b/docs/resources/sudo_rule_denycmd_membership.md
@@ -1,7 +1,7 @@
 ---
 page_title: "freeipa_sudo_rule_denycmd_membership Resource - freeipa"
 description: |-
-FreeIPA Sudo rule deny command membership resource
+  FreeIPA Sudo rule deny command membership resource
 ---
 
 # freeipa_sudo_rule_denycmd_membership (Resource)

--- a/docs/resources/sudo_rule_host_membership.md
+++ b/docs/resources/sudo_rule_host_membership.md
@@ -1,7 +1,7 @@
 ---
 page_title: "freeipa_sudo_rule_host_membership Resource - freeipa"
 description: |-
-FreeIPA Sudo rule host membership resource
+  FreeIPA Sudo rule host membership resource
 ---
 
 # freeipa_sudo_rule_host_membership (Resource)

--- a/docs/resources/sudo_rule_option.md
+++ b/docs/resources/sudo_rule_option.md
@@ -1,7 +1,7 @@
 ---
 page_title: "freeipa_sudo_rule_option Resource - freeipa"
 description: |-
-FreeIPA Sudo rule option resource
+  FreeIPA Sudo rule option resource
 ---
 
 # freeipa_sudo_rule_option (Resource)

--- a/docs/resources/sudo_rule_runasgroup_membership.md
+++ b/docs/resources/sudo_rule_runasgroup_membership.md
@@ -1,7 +1,7 @@
 ---
 page_title: "freeipa_sudo_rule_runasgroup_membership Resource - freeipa"
 description: |-
-FreeIPA Sudo rule run as group membership resource
+  FreeIPA Sudo rule run as group membership resource
 ---
 
 # freeipa_sudo_rule_runasgroup_membership (Resource)

--- a/docs/resources/sudo_rule_runasuser_membership.md
+++ b/docs/resources/sudo_rule_runasuser_membership.md
@@ -1,7 +1,7 @@
 ---
 page_title: "freeipa_sudo_rule_runasuser_membership Resource - freeipa"
 description: |-
-FreeIPA Sudo rule run as user membership resource
+  FreeIPA Sudo rule run as user membership resource
 ---
 
 # freeipa_sudo_rule_runasuser_membership (Resource)

--- a/docs/resources/sudo_rule_user_membership.md
+++ b/docs/resources/sudo_rule_user_membership.md
@@ -1,7 +1,7 @@
 ---
 page_title: "freeipa_sudo_rule_user_membership Resource - freeipa"
 description: |-
-FreeIPA Sudo rule user membership resource
+  FreeIPA Sudo rule user membership resource
 ---
 
 # freeipa_sudo_rule_user_membership (Resource)

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -1,7 +1,7 @@
 ---
 page_title: "freeipa_user Resource - freeipa"
 description: |-
-FreeIPA User resource
+  FreeIPA User resource
 ---
 
 # freeipa_user (Resource)
@@ -33,14 +33,14 @@ resource "freeipa_user" "user-1" {
 # - `last_name`
 
 import {
-    to = freeipa_user.testuser
-    id = "testuser"
+  to = freeipa_user.testuser
+  id = "testuser"
 }
 
 resource "freeipa_user" "testuser" {
-    name       = "testuser"
-    first_name = "Test"
-    last_name  = "User"
+  name       = "testuser"
+  first_name = "Test"
+  last_name  = "User"
 }
 ```
 

--- a/docs/resources/user_group_membership.md
+++ b/docs/resources/user_group_membership.md
@@ -1,7 +1,7 @@
 ---
 page_title: "freeipa_user_group_membership Resource - freeipa"
 description: |-
-FreeIPA User Group Membership resource
+  FreeIPA User Group Membership resource
 ---
 
 # freeipa_user_group_membership (Resource)

--- a/freeipa/automember_condition_resource.go
+++ b/freeipa/automember_condition_resource.go
@@ -63,7 +63,7 @@ func (r *AutomemberConditionResource) ConfigValidators(ctx context.Context) []re
 func (r *AutomemberConditionResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		// This description is used by the documentation generator and the language server.
-		MarkdownDescription: "FreeIPA Automember conditionresource",
+		MarkdownDescription: "FreeIPA Automember condition resource",
 
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{

--- a/freeipa/host_resource.go
+++ b/freeipa/host_resource.go
@@ -82,7 +82,7 @@ func (r *HostResource) ConfigValidators(ctx context.Context) []resource.ConfigVa
 func (r *HostResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		// This description is used by the documentation generator and the language server.
-		MarkdownDescription: "FreeIPA User resource",
+		MarkdownDescription: "FreeIPA Host resource",
 
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{

--- a/freeipa/hostgroup_data_source.go
+++ b/freeipa/hostgroup_data_source.go
@@ -61,7 +61,7 @@ func (r *HostGroupDataSource) Metadata(ctx context.Context, req datasource.Metad
 func (r *HostGroupDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		// This description is used by the documentation generator and the language server.
-		MarkdownDescription: "FreeIPA User Group data source",
+		MarkdownDescription: "FreeIPA Host Group data source",
 
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{

--- a/freeipa/hostgroup_resource .go
+++ b/freeipa/hostgroup_resource .go
@@ -59,7 +59,7 @@ func (r *HostGroupResource) ConfigValidators(ctx context.Context) []resource.Con
 func (r *HostGroupResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		// This description is used by the documentation generator and the language server.
-		MarkdownDescription: "FreeIPA User Group resource",
+		MarkdownDescription: "FreeIPA Host Group resource",
 
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{

--- a/freeipa/sudo_cmdgroup_data_source.go
+++ b/freeipa/sudo_cmdgroup_data_source.go
@@ -51,7 +51,7 @@ func (r *SudoCmdGroupDataSource) Metadata(ctx context.Context, req datasource.Me
 func (r *SudoCmdGroupDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		// This description is used by the documentation generator and the language server.
-		MarkdownDescription: "FreeIPA User sudo command group data source",
+		MarkdownDescription: "FreeIPA Sudo command group data source",
 
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{

--- a/freeipa/sudo_rule_data_source.go
+++ b/freeipa/sudo_rule_data_source.go
@@ -68,7 +68,7 @@ func (r *SudoRuleDataSource) Metadata(ctx context.Context, req datasource.Metada
 func (r *SudoRuleDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		// This description is used by the documentation generator and the language server.
-		MarkdownDescription: "FreeIPA User sudo rule data source",
+		MarkdownDescription: "FreeIPA Sudo rule data source",
 
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{

--- a/templates/data-sources.md.tmpl
+++ b/templates/data-sources.md.tmpl
@@ -1,7 +1,7 @@
 ---
 page_title: "{{ .Name }} {{ .Type }} - {{ .ProviderShortName }}"
 description: |-
-{{.Description}}
+  {{ .Description }}
 ---
 
 # {{ .Name }} ({{ .Type }})

--- a/templates/resources.md.tmpl
+++ b/templates/resources.md.tmpl
@@ -1,7 +1,7 @@
 ---
 page_title: "{{ .Name }} {{ .Type }} - {{ .ProviderShortName }}"
 description: |-
-{{.Description}}
+  {{ .Description }}
 ---
 
 # {{ .Name }} ({{ .Type }})


### PR DESCRIPTION
The resource description is not displayed in the terraform registry's pages.

Indentation is wrong in the templates:
```
description: |-
{{ .Description }}
```
I couldn't see the final result as it is generated server side by terraform registry but this should fix it in theory.

Also fixed some copy paste errors in the resources descriptions.
And of course regenerated the docs.

No need for a new release for this