### PR TITLE
fix: throw a warning when a membership resource adds an existing member

### DIFF
--- a/docs/resources/hbac_policy_host_membership.md
+++ b/docs/resources/hbac_policy_host_membership.md
@@ -1,7 +1,8 @@
 ---
 page_title: "freeipa_hbac_policy_host_membership Resource - freeipa"
 description: |-
-  FreeIPA HBAC policy host membership resource
+  FreeIPA HBAC policy host membership resource.
+  Adding a member that already exist in FreeIPA will result in a warning but the member will be added to the state.
 ---
 
 # freeipa_hbac_policy_host_membership (Resource)

--- a/docs/resources/hbac_policy_service_membership.md
+++ b/docs/resources/hbac_policy_service_membership.md
@@ -1,7 +1,8 @@
 ---
 page_title: "freeipa_hbac_policy_service_membership Resource - freeipa"
 description: |-
-  FreeIPA HBAC policy service membership resource
+  FreeIPA HBAC policy service membership resource.
+  Adding a member that already exist in FreeIPA will result in a warning but the member will be added to the state.
 ---
 
 # freeipa_hbac_policy_service_membership (Resource)

--- a/docs/resources/hbac_policy_user_membership.md
+++ b/docs/resources/hbac_policy_user_membership.md
@@ -1,7 +1,8 @@
 ---
 page_title: "freeipa_hbac_policy_user_membership Resource - freeipa"
 description: |-
-  FreeIPA HBAC policy host membership resource
+  FreeIPA HBAC policy host membership resource.
+  Adding a member that already exist in FreeIPA will result in a warning but the member will be added to the state.
 ---
 
 # freeipa_hbac_policy_user_membership (Resource)

--- a/docs/resources/host_hostgroup_membership.md
+++ b/docs/resources/host_hostgroup_membership.md
@@ -1,7 +1,8 @@
 ---
 page_title: "freeipa_host_hostgroup_membership Resource - freeipa"
 description: |-
-  FreeIPA User Group Membership resource
+  FreeIPA User Group Membership resource.
+  Adding a member that already exist in FreeIPA will result in a warning but the member will be added to the state.
 ---
 
 # freeipa_host_hostgroup_membership (Resource)

--- a/docs/resources/sudo_cmdgroup_membership.md
+++ b/docs/resources/sudo_cmdgroup_membership.md
@@ -1,7 +1,8 @@
 ---
 page_title: "freeipa_sudo_cmdgroup_membership Resource - freeipa"
 description: |-
-  FreeIPA Sudo command group membership resource
+  FreeIPA Sudo command group membership resource.
+  Adding a member that already exist in FreeIPA will result in a warning but the member will be added to the state.
 ---
 
 # freeipa_sudo_cmdgroup_membership (Resource)

--- a/docs/resources/sudo_rule_allowcmd_membership.md
+++ b/docs/resources/sudo_rule_allowcmd_membership.md
@@ -1,7 +1,8 @@
 ---
 page_title: "freeipa_sudo_rule_allowcmd_membership Resource - freeipa"
 description: |-
-  FreeIPA Sudo rule allow command membership resource
+  FreeIPA Sudo rule allow command membership resource.
+  Adding a member that already exist in FreeIPA will result in a warning but the member will be added to the state.
 ---
 
 # freeipa_sudo_rule_allowcmd_membership (Resource)

--- a/docs/resources/sudo_rule_denycmd_membership.md
+++ b/docs/resources/sudo_rule_denycmd_membership.md
@@ -1,7 +1,8 @@
 ---
 page_title: "freeipa_sudo_rule_denycmd_membership Resource - freeipa"
 description: |-
-  FreeIPA Sudo rule deny command membership resource
+  FreeIPA Sudo rule deny command membership resource.
+  Adding a member that already exist in FreeIPA will result in a warning but the member will be added to the state.
 ---
 
 # freeipa_sudo_rule_denycmd_membership (Resource)

--- a/docs/resources/sudo_rule_host_membership.md
+++ b/docs/resources/sudo_rule_host_membership.md
@@ -1,7 +1,8 @@
 ---
 page_title: "freeipa_sudo_rule_host_membership Resource - freeipa"
 description: |-
-  FreeIPA Sudo rule host membership resource
+  FreeIPA Sudo rule host membership resource.
+  Adding a member that already exist in FreeIPA will result in a warning but the member will be added to the state.
 ---
 
 # freeipa_sudo_rule_host_membership (Resource)

--- a/docs/resources/sudo_rule_runasgroup_membership.md
+++ b/docs/resources/sudo_rule_runasgroup_membership.md
@@ -1,7 +1,8 @@
 ---
 page_title: "freeipa_sudo_rule_runasgroup_membership Resource - freeipa"
 description: |-
-  FreeIPA Sudo rule run as group membership resource
+  FreeIPA Sudo rule run as group membership resource.
+  Adding a member that already exist in FreeIPA will result in a warning but the member will be added to the state.
 ---
 
 # freeipa_sudo_rule_runasgroup_membership (Resource)

--- a/docs/resources/sudo_rule_runasuser_membership.md
+++ b/docs/resources/sudo_rule_runasuser_membership.md
@@ -1,7 +1,8 @@
 ---
 page_title: "freeipa_sudo_rule_runasuser_membership Resource - freeipa"
 description: |-
-  FreeIPA Sudo rule run as user membership resource
+  FreeIPA Sudo rule run as user membership resource.
+  Adding a member that already exist in FreeIPA will result in a warning but the member will be added to the state.
 ---
 
 # freeipa_sudo_rule_runasuser_membership (Resource)

--- a/docs/resources/sudo_rule_user_membership.md
+++ b/docs/resources/sudo_rule_user_membership.md
@@ -1,7 +1,8 @@
 ---
 page_title: "freeipa_sudo_rule_user_membership Resource - freeipa"
 description: |-
-  FreeIPA Sudo rule user membership resource
+  FreeIPA Sudo rule user membership resource.
+  Adding a member that already exist in FreeIPA will result in a warning but the member will be added to the state.
 ---
 
 # freeipa_sudo_rule_user_membership (Resource)

--- a/docs/resources/user_group_membership.md
+++ b/docs/resources/user_group_membership.md
@@ -1,7 +1,8 @@
 ---
 page_title: "freeipa_user_group_membership Resource - freeipa"
 description: |-
-  FreeIPA User Group Membership resource
+  FreeIPA User Group Membership resource.
+  Adding a member that already exist in FreeIPA will result in a warning but the member will be added to the state.
 ---
 
 # freeipa_user_group_membership (Resource)

--- a/freeipa/hbac_policy_host_membership_resource.go
+++ b/freeipa/hbac_policy_host_membership_resource.go
@@ -87,7 +87,7 @@ func (r *HbacPolicyHostMembershipResource) ConfigValidators(ctx context.Context)
 func (r *HbacPolicyHostMembershipResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		// This description is used by the documentation generator and the language server.
-		MarkdownDescription: "FreeIPA HBAC policy host membership resource",
+		MarkdownDescription: "FreeIPA HBAC policy host membership resource.\nAdding a member that already exist in FreeIPA will result in a warning but the member will be added to the state.",
 
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
@@ -208,10 +208,13 @@ func (r *HbacPolicyHostMembershipResource) Create(ctx context.Context, req resou
 		cmd_id = "mh"
 	}
 
-	_, err := r.client.HbacruleAddHost(&args, &optArgs)
+	_v, err := r.client.HbacruleAddHost(&args, &optArgs)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Error creating freeipa sudo rule host membership: %s", err))
 		return
+	}
+	if _v.Completed == 0 {
+		resp.Diagnostics.AddWarning("Client Warning", fmt.Sprintf("Warning creating freeipa sudo rule host membership: %v", _v.Failed))
 	}
 
 	switch cmd_id {
@@ -411,8 +414,7 @@ func (r *HbacPolicyHostMembershipResource) Update(ctx context.Context, req resou
 			return
 		}
 		if _v.Completed == 0 {
-			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Error creating freeipa hbac policy host membership: %v", _v.Failed))
-			return
+			resp.Diagnostics.AddWarning("Client Warning", fmt.Sprintf("Warning creating freeipa sudo rule host membership: %v", _v.Failed))
 		}
 	}
 	if hasMemberDel {

--- a/freeipa/hbac_policy_service_membership_resource .go
+++ b/freeipa/hbac_policy_service_membership_resource .go
@@ -87,7 +87,7 @@ func (r *HbacPolicyServiceMembershipResource) ConfigValidators(ctx context.Conte
 func (r *HbacPolicyServiceMembershipResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		// This description is used by the documentation generator and the language server.
-		MarkdownDescription: "FreeIPA HBAC policy service membership resource",
+		MarkdownDescription: "FreeIPA HBAC policy service membership resource.\nAdding a member that already exist in FreeIPA will result in a warning but the member will be added to the state.",
 
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
@@ -208,10 +208,13 @@ func (r *HbacPolicyServiceMembershipResource) Create(ctx context.Context, req re
 		user_id = "ms"
 	}
 
-	_, err := r.client.HbacruleAddService(&args, &optArgs)
+	_v, err := r.client.HbacruleAddService(&args, &optArgs)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Error creating freeipa sudo rule service membership: %s", err))
 		return
+	}
+	if _v.Completed == 0 {
+		resp.Diagnostics.AddWarning("Client Warning", fmt.Sprintf("Warning creating freeipa sudo rule service membership: %v", _v.Failed))
 	}
 
 	switch user_id {
@@ -411,8 +414,7 @@ func (r *HbacPolicyServiceMembershipResource) Update(ctx context.Context, req re
 			return
 		}
 		if _v.Completed == 0 {
-			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Error creating freeipa hbac policy service membership: %v", _v.Failed))
-			return
+			resp.Diagnostics.AddWarning("Client Warning", fmt.Sprintf("Warning creating freeipa sudo rule service membership: %v", _v.Failed))
 		}
 	}
 	if hasMemberDel {

--- a/freeipa/host_hostgroup_membership_resource.go
+++ b/freeipa/host_hostgroup_membership_resource.go
@@ -93,7 +93,7 @@ func (r *HostGroupMembership) ConfigValidators(ctx context.Context) []resource.C
 func (r *HostGroupMembership) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		// This description is used by the documentation generator and the language server.
-		MarkdownDescription: "FreeIPA User Group Membership resource",
+		MarkdownDescription: "FreeIPA User Group Membership resource.\nAdding a member that already exist in FreeIPA will result in a warning but the member will be added to the state.",
 
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
@@ -227,8 +227,7 @@ func (r *HostGroupMembership) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 	if _v.Completed == 0 {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Error creating freeipa hostgroup membership: %v", _v.Failed))
-		return
+		resp.Diagnostics.AddWarning("Client Warning", fmt.Sprintf("Warning creating freeipa hostgroup membership: %v", _v.Failed))
 	}
 
 	// Save data into Terraform state
@@ -432,8 +431,7 @@ func (r *HostGroupMembership) Update(ctx context.Context, req resource.UpdateReq
 			return
 		}
 		if _v.Completed == 0 {
-			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Error creating freeipa hostgroup membership: %v", _v.Failed))
-			return
+			resp.Diagnostics.AddWarning("Client Warning", fmt.Sprintf("Warning creating freeipa hostgroup membership: %v", _v.Failed))
 		}
 	}
 	if hasMemberDel {

--- a/freeipa/sudo_rule_runasgroup_membership_resource.go
+++ b/freeipa/sudo_rule_runasgroup_membership_resource.go
@@ -69,7 +69,7 @@ func (r *SudoRuleRunAsGroupMembershipResource) ConfigValidators(ctx context.Cont
 func (r *SudoRuleRunAsGroupMembershipResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		// This description is used by the documentation generator and the language server.
-		MarkdownDescription: "FreeIPA Sudo rule run as group membership resource",
+		MarkdownDescription: "FreeIPA Sudo rule run as group membership resource.\nAdding a member that already exist in FreeIPA will result in a warning but the member will be added to the state.",
 
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
@@ -162,10 +162,13 @@ func (r *SudoRuleRunAsGroupMembershipResource) Create(ctx context.Context, req r
 		grp_id = "msrraug"
 	}
 
-	_, err := r.client.SudoruleAddRunasgroup(&args, &optArgs)
+	_v, err := r.client.SudoruleAddRunasgroup(&args, &optArgs)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Error creating freeipa sudo rule runasgroup membership: %s", err))
 		return
+	}
+	if _v.Completed == 0 {
+		resp.Diagnostics.AddWarning("Client Warning", fmt.Sprintf("Warning creating freeipa sudo rule runasgroup membership: %v", _v.Failed))
 	}
 
 	switch grp_id {
@@ -313,8 +316,7 @@ func (r *SudoRuleRunAsGroupMembershipResource) Update(ctx context.Context, req r
 			return
 		}
 		if _v.Completed == 0 {
-			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Error creating freeipa sudo rule runasgroup membership: %v", _v.Failed))
-			return
+			resp.Diagnostics.AddWarning("Client Warning", fmt.Sprintf("Warning creating freeipa sudo rule runasgroup membership: %v", _v.Failed))
 		}
 	}
 	if hasMemberDel {

--- a/freeipa/user_group_membership_resource.go
+++ b/freeipa/user_group_membership_resource.go
@@ -127,7 +127,7 @@ func (r *userGroupMembership) ConfigValidators(ctx context.Context) []resource.C
 func (r *userGroupMembership) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		// This description is used by the documentation generator and the language server.
-		MarkdownDescription: "FreeIPA User Group Membership resource",
+		MarkdownDescription: "FreeIPA User Group Membership resource.\nAdding a member that already exist in FreeIPA will result in a warning but the member will be added to the state.",
 
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
@@ -287,8 +287,7 @@ func (r *userGroupMembership) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 	if _v.Completed == 0 {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Error creating freeipa user group membership: %v", _v.Failed))
-		return
+		resp.Diagnostics.AddWarning("Client Warning", fmt.Sprintf("Warning creating freeipa user group membership: %v", _v.Failed))
 	}
 
 	if !data.ExternalMember.IsNull() {
@@ -601,8 +600,7 @@ func (r *userGroupMembership) Update(ctx context.Context, req resource.UpdateReq
 			return
 		}
 		if _v.Completed == 0 {
-			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Error creating freeipa user group membership: %v", _v.Failed))
-			return
+			resp.Diagnostics.AddWarning("Client Warning", fmt.Sprintf("Warning creating freeipa user group membership: %v", _v.Failed))
 		}
 		if memberAddOptArgs.Ipaexternalmember != nil {
 			z := new(bool)

--- a/templates/data-sources.md.tmpl
+++ b/templates/data-sources.md.tmpl
@@ -1,7 +1,7 @@
 ---
 page_title: "{{ .Name }} {{ .Type }} - {{ .ProviderShortName }}"
 description: |-
-  {{ .Description }}
+{{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---
 
 # {{ .Name }} ({{ .Type }})

--- a/templates/resources.md.tmpl
+++ b/templates/resources.md.tmpl
@@ -1,7 +1,7 @@
 ---
 page_title: "{{ .Name }} {{ .Type }} - {{ .ProviderShortName }}"
 description: |-
-  {{ .Description }}
+{{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---
 
 # {{ .Name }} ({{ .Type }})


### PR DESCRIPTION
For all membership resources:
- During create, throw a warning if no error when adding a member but no change was made (= member already exist in freeipa)
- During update, throw a warning if no error when adding a member but no change was made (= member already exist in freeipa)
- Update documentation to describe this behavior

Additionally: fix for multi-line resource description in the documentation.

Resolves #77 