### PR TITLE
fix: provider crash if user doesn't have enough permissions

### DIFF
--- a/freeipa/automember_resource.go
+++ b/freeipa/automember_resource.go
@@ -290,12 +290,12 @@ func (r *AutomemberResource) Update(ctx context.Context, req resource.UpdateRequ
 		optArgs.Setattr = &v
 	}
 
-	res, err := r.client.AutomemberMod(&args, &optArgs)
+	_, err := r.client.AutomemberMod(&args, &optArgs)
 	if err != nil {
 		if strings.Contains(err.Error(), "EmptyModlist") {
 			resp.Diagnostics.AddWarning("Client Warning", err.Error())
 		} else {
-			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Error update freeipa automember rule %s: %s", res.Result.Cn, err))
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Error update freeipa automember rule %s: %s", data.Id.ValueString(), err))
 			return
 		}
 	}

--- a/freeipa/group_resource.go
+++ b/freeipa/group_resource.go
@@ -345,12 +345,12 @@ func (r *UserGroupResource) Update(ctx context.Context, req resource.UpdateReque
 		optArgs.Setattr = &v
 	}
 
-	res, err := r.client.GroupMod(&args, &optArgs)
+	_, err := r.client.GroupMod(&args, &optArgs)
 	if err != nil {
 		if strings.Contains(err.Error(), "EmptyModlist") {
 			resp.Diagnostics.AddWarning("Client Warning", err.Error())
 		} else {
-			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Error update freeipa group %s: %s", res.Result.Cn, err))
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Error update freeipa group %s: %s", data.Name.ValueString(), err))
 			return
 		}
 	}

--- a/freeipa/hostgroup_resource .go
+++ b/freeipa/hostgroup_resource .go
@@ -209,12 +209,12 @@ func (r *HostGroupResource) Update(ctx context.Context, req resource.UpdateReque
 	if !data.Description.Equal(state.Description) {
 		optArgs.Description = data.Description.ValueStringPointer()
 	}
-	res, err := r.client.HostgroupMod(&args, &optArgs)
+	_, err := r.client.HostgroupMod(&args, &optArgs)
 	if err != nil {
 		if strings.Contains(err.Error(), "EmptyModlist") {
 			resp.Diagnostics.AddWarning("Client Warning", err.Error())
 		} else {
-			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Error update freeipa group %s: %s", res.Result.Cn, err))
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Error update freeipa group %s: %s", data.Name.ValueString(), err))
 			return
 		}
 	}


### PR DESCRIPTION
when there is a permission denied, the response to the api query doesn't contain a body.
Therefore the `res.Result.Cn` is not referenced and the provider crash when trying to process the error.