### PR TITLE
fix: host otp returned only at creation and update dns on host deletion

### DIFF
--- a/docs/resources/host.md
+++ b/docs/resources/host.md
@@ -65,6 +65,7 @@ resource "freeipa_host" "testhost" {
 - `random_password` (Boolean) Generate a random password to be used in bulk enrollment
 - `trusted_for_delegation` (Boolean) Client credentials may be delegated to the service
 - `trusted_to_auth_as_delegate` (Boolean) The service is allowed to authenticate on behalf of a client
+- `update_dns` (Boolean) Update DNS when updating or deleting the host (default to `true`)
 - `user_certificates` (List of String) Base-64 encoded host certificate
 - `userclass` (List of String) Host category (semantics placed on this attribute are for local interpretation)
 - `userpassword` (String, Sensitive) Password used in bulk enrollment


### PR DESCRIPTION
When creating a host with `randompassword = true` the `generated_password` is correctly returned and put in the state.
However, on subsequent plans, the generated_password is set to null. This can be an issue if you want to reuse the password later for enrollment.

The reason is that the freeipa api returns the generated password only when it is created.
This fix ensures that Read function never changes the value of `generated_password`. 

I have made an additional fix to add a `update_dns` attribute. (defaults to true for backward compatibility reason. 
When set to `false` modiying or deleting a host will not remove the dns entries at the same time. Useful if you want to manage the dns records of the host from another resource or outside of terraform.