### PR TITLE
fix: delete host records on host delete

### DIFF
--- a/docs/data-sources/dns_record.md
+++ b/docs/data-sources/dns_record.md
@@ -34,4 +34,13 @@ data "freeipa_dns_record" "dns-zone-1" {
 
 ### Read-Only
 
+- `a_records` (Set of String) List of A records
+- `aaaa_records` (Set of String) List of AAAA records
+- `cname_records` (Set of String) List of CNAME records
 - `id` (String) ID of the resource
+- `mx_records` (Set of String) List of MX records
+- `ns_records` (Set of String) List of NS records
+- `ptr_records` (Set of String) List of PTR records
+- `srv_records` (Set of String) List of SRV records
+- `sshfp_records` (Set of String) List of SSHFP records
+- `txt_records` (Set of String) List of TXT records

--- a/freeipa/helper_test.go
+++ b/freeipa/helper_test.go
@@ -325,6 +325,15 @@ func testAccFreeIPADNSRecord_resource(dataset map[string]string) string {
 	return tf_def
 }
 
+func testAccFreeIPADNSRecord_datasource(dataset map[string]string) string {
+	return fmt.Sprintf(`
+	data "freeipa_dns_record" "dns-record-%s" {
+	  zone_name   = %s
+	  record_name = %s
+	}
+	`, dataset["index"], dataset["zone_name"], dataset["record_name"])
+}
+
 func testAccFreeIPAHost_resource(dataset map[string]string) string {
 	tf_def := fmt.Sprintf(`
 	resource "freeipa_host" "host-%s" {

--- a/freeipa/host_data_source.go
+++ b/freeipa/host_data_source.go
@@ -312,7 +312,6 @@ func (r *HostDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 		data.MemberOfIndirectSudoRule, _ = types.ListValueFrom(ctx, types.StringType, res.Result.MemberofindirectSudorule)
 	}
 
-	data.Id = data.Name
 	tflog.Debug(ctx, fmt.Sprintf("[DEBUG] Read freeipa host %s", res.Result.Fqdn))
 
 	data.Id = types.StringValue(data.Name.ValueString())

--- a/freeipa/host_resource.go
+++ b/freeipa/host_resource.go
@@ -682,7 +682,7 @@ func (r *HostResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 		_, err = r.client.DnsrecordDel(&dnsArg, &dnsOptArgs)
 		if err != nil {
 			if strings.Contains(err.Error(), "NotFound") {
-				tflog.Debug(ctx, fmt.Sprintf("[DEBUG] No DNS recordsfound for host %s", data.Id.ValueString()))
+				tflog.Debug(ctx, fmt.Sprintf("[DEBUG] No DNS records found for host %s", data.Id.ValueString()))
 			} else {
 				resp.Diagnostics.AddError("Client Error", fmt.Sprintf("DNS records deletion for host %s failed: %s", data.Id.ValueString(), err))
 				return


### PR DESCRIPTION
Fixes #91 

If 'update_dns` is `true` then delete all dns records under the the hostname.

The dns record name is the first part of the hostname (left of first '.') and the domain is the right part (right of first '.').

This will also remove any entry added to the record afterwards. If other host records are managed by terraform, it will conflict and the admin should not use `update_dns` and manage all dns records outside of this resource