### PR TITLE
fix: freeipa_dns_record support TLSA records

### DIFF
--- a/docs/data-sources/dns_record.md
+++ b/docs/data-sources/dns_record.md
@@ -43,4 +43,5 @@ data "freeipa_dns_record" "dns-zone-1" {
 - `ptr_records` (Set of String) List of PTR records
 - `srv_records` (Set of String) List of SRV records
 - `sshfp_records` (Set of String) List of SSHFP records
+- `tlsa_records` (Set of String) List of TLSA records
 - `txt_records` (Set of String) List of TXT records

--- a/docs/resources/dns_record.md
+++ b/docs/resources/dns_record.md
@@ -86,7 +86,7 @@ resource "freeipa_dns_record" "ptrrecord" {
 
 - `name` (String) Record name
 - `records` (Set of String) A string list of records
-- `type` (String) The record type (A, AAAA, CNAME, MX, PTR, SRV, TXT, SSHFP, NS)
+- `type` (String) The record type (A, AAAA, CNAME, MX, PTR, SRV, TXT, SSHFP, NS, TLSA)
 - `zone_name` (String) Zone name (FQDN)
 
 ### Optional

--- a/freeipa/dns_record_data_source.go
+++ b/freeipa/dns_record_data_source.go
@@ -51,6 +51,7 @@ type dnsRecordDataSourceModel struct {
 	TxtRecords   types.Set    `tfsdk:"txt_records"`
 	SshfpRecords types.Set    `tfsdk:"sshfp_records"`
 	NsRecords    types.Set    `tfsdk:"ns_records"`
+	TlsaRecords  types.Set    `tfsdk:"tlsa_records"`
 }
 
 func (r *dnsRecordDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
@@ -121,6 +122,11 @@ func (r *dnsRecordDataSource) Schema(ctx context.Context, req datasource.SchemaR
 			},
 			"ns_records": schema.SetAttribute{
 				MarkdownDescription: "List of NS records",
+				Computed:            true,
+				ElementType:         types.StringType,
+			},
+			"tlsa_records": schema.SetAttribute{
+				MarkdownDescription: "List of TLSA records",
 				Computed:            true,
 				ElementType:         types.StringType,
 			},
@@ -240,6 +246,13 @@ func (r *dnsRecordDataSource) Read(ctx context.Context, req datasource.ReadReque
 	if res.Result.Nsrecord != nil {
 		var diag diag.Diagnostics
 		data.NsRecords, diag = types.SetValueFrom(ctx, types.StringType, res.Result.Nsrecord)
+		if diag.HasError() {
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("diag: %v\n", diag))
+		}
+	}
+	if res.Result.Tlsarecord != nil {
+		var diag diag.Diagnostics
+		data.TlsaRecords, diag = types.SetValueFrom(ctx, types.StringType, res.Result.Tlsarecord)
 		if diag.HasError() {
 			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("diag: %v\n", diag))
 		}

--- a/freeipa/dns_record_resource.go
+++ b/freeipa/dns_record_resource.go
@@ -93,13 +93,13 @@ func (r *DNSRecordResource) Schema(ctx context.Context, req resource.SchemaReque
 				},
 			},
 			"type": schema.StringAttribute{
-				MarkdownDescription: "The record type (A, AAAA, CNAME, MX, PTR, SRV, TXT, SSHFP, NS)",
+				MarkdownDescription: "The record type (A, AAAA, CNAME, MX, PTR, SRV, TXT, SSHFP, NS, TLSA)",
 				Required:            true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
 				Validators: []validator.String{
-					stringvalidator.OneOf("A", "AAAA", "CNAME", "MX", "PTR", "SRV", "TXT", "SSHFP", "NS"),
+					stringvalidator.OneOf("A", "AAAA", "CNAME", "MX", "PTR", "SRV", "TXT", "SSHFP", "NS", "TLSA"),
 				},
 			},
 			"records": schema.SetAttribute{
@@ -191,6 +191,8 @@ func (r *DNSRecordResource) Create(ctx context.Context, req resource.CreateReque
 			optArgs.Txtrecord = &records
 		case "SSHFP":
 			optArgs.Sshfprecord = &records
+		case "TLSA":
+			optArgs.Tlsarecord = &records
 		}
 	}
 
@@ -299,6 +301,10 @@ func (r *DNSRecordResource) Read(ctx context.Context, req resource.ReadRequest, 
 		if res.Result.Sshfprecord != nil {
 			data.Records, _ = types.SetValueFrom(ctx, types.StringType, res.Result.Sshfprecord)
 		}
+	case "TLSA":
+		if res.Result.Tlsarecord != nil {
+			data.Records, _ = types.SetValueFrom(ctx, types.StringType, res.Result.Tlsarecord)
+		}
 	}
 
 	if res.Result.Dnsttl != nil && !data.TTL.IsNull() {
@@ -371,6 +377,8 @@ func (r *DNSRecordResource) Update(ctx context.Context, req resource.UpdateReque
 			optArgs.Txtrecord = &records
 		case "SSHFP":
 			optArgs.Sshfprecord = &records
+		case "TLSA":
+			optArgs.Tlsarecord = &records
 		}
 	}
 
@@ -446,6 +454,8 @@ func (r *DNSRecordResource) Delete(ctx context.Context, req resource.DeleteReque
 			optArgs.Txtrecord = &records
 		case "SSHFP":
 			optArgs.Sshfprecord = &records
+		case "TLSA":
+			optArgs.Tlsarecord = &records
 		}
 	}
 
@@ -524,6 +534,10 @@ func (r *DNSRecordResource) ImportState(ctx context.Context, req resource.Import
 	case "SSHFP":
 		if res.Result.Sshfprecord != nil {
 			resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("records"), *res.Result.Sshfprecord)...)
+		}
+	case "TLSA":
+		if res.Result.Tlsarecord != nil {
+			resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("records"), *res.Result.Tlsarecord)...)
 		}
 	}
 


### PR DESCRIPTION
Fixes #101 

This PR adds support for TLSA records in the freeipa_dns_record resource