### PR TITLE
feat(provider): lazy-load ipa.Client on resource/datasource configure

### DIFF
--- a/freeipa/automember_condition_resource.go
+++ b/freeipa/automember_condition_resource.go
@@ -132,14 +132,24 @@ func (r *AutomemberConditionResource) Configure(ctx context.Context, req resourc
 		return
 	}
 
-	client, ok := req.ProviderData.(*ipa.Client)
-
+	config, ok := req.ProviderData.(*freeipaProviderModel)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *http.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *freeipaProviderModel, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
+		return
+	}
 
+	p := &freeipaProvider{}
+	client, err := p.NewFreeIPAClient(ctx, config)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Create FreeIPA API Client",
+			"An unexpected error occurred when creating the FreeIPA API client. "+
+				"If the error is not clear, please contact the provider developers.\n\n"+
+				"FreeIPA Client Error: "+err.Error(),
+		)
 		return
 	}
 

--- a/freeipa/automember_resource.go
+++ b/freeipa/automember_resource.go
@@ -113,14 +113,24 @@ func (r *AutomemberResource) Configure(ctx context.Context, req resource.Configu
 		return
 	}
 
-	client, ok := req.ProviderData.(*ipa.Client)
-
+	config, ok := req.ProviderData.(*freeipaProviderModel)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *http.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *freeipaProviderModel, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
+		return
+	}
 
+	p := &freeipaProvider{}
+	client, err := p.NewFreeIPAClient(ctx, config)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Create FreeIPA API Client",
+			"An unexpected error occurred when creating the FreeIPA API client. "+
+				"If the error is not clear, please contact the provider developers.\n\n"+
+				"FreeIPA Client Error: "+err.Error(),
+		)
 		return
 	}
 

--- a/freeipa/dns_forward_zone_resource.go
+++ b/freeipa/dns_forward_zone_resource.go
@@ -93,14 +93,27 @@ func (r *dnsForwardZone) Configure(ctx context.Context, req resource.ConfigureRe
 	if req.ProviderData == nil {
 		return
 	}
-	client, ok := req.ProviderData.(*ipa.Client)
+	config, ok := req.ProviderData.(*freeipaProviderModel)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *ipa.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *freeipaProviderModel, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 		return
 	}
+
+	p := &freeipaProvider{}
+	client, err := p.NewFreeIPAClient(ctx, config)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Create FreeIPA API Client",
+			"An unexpected error occurred when creating the FreeIPA API client. "+
+				"If the error is not clear, please contact the provider developers.\n\n"+
+				"FreeIPA Client Error: "+err.Error(),
+		)
+		return
+	}
+
 	r.client = client
 }
 

--- a/freeipa/dns_global_config_resource.go
+++ b/freeipa/dns_global_config_resource.go
@@ -98,14 +98,27 @@ func (r *dnsGlobalConfig) Configure(ctx context.Context, req resource.ConfigureR
 	if req.ProviderData == nil {
 		return
 	}
-	client, ok := req.ProviderData.(*ipa.Client)
+	config, ok := req.ProviderData.(*freeipaProviderModel)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *ipa.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *freeipaProviderModel, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 		return
 	}
+
+	p := &freeipaProvider{}
+	client, err := p.NewFreeIPAClient(ctx, config)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Create FreeIPA API Client",
+			"An unexpected error occurred when creating the FreeIPA API client. "+
+				"If the error is not clear, please contact the provider developers.\n\n"+
+				"FreeIPA Client Error: "+err.Error(),
+		)
+		return
+	}
+
 	r.client = client
 }
 

--- a/freeipa/dns_record_data_source.go
+++ b/freeipa/dns_record_data_source.go
@@ -140,14 +140,24 @@ func (r *dnsRecordDataSource) Configure(ctx context.Context, req datasource.Conf
 		return
 	}
 
-	client, ok := req.ProviderData.(*ipa.Client)
-
+	config, ok := req.ProviderData.(*freeipaProviderModel)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *http.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *freeipaProviderModel, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
+		return
+	}
 
+	p := &freeipaProvider{}
+	client, err := p.NewFreeIPAClient(ctx, config)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Create FreeIPA API Client",
+			"An unexpected error occurred when creating the FreeIPA API client. "+
+				"If the error is not clear, please contact the provider developers.\n\n"+
+				"FreeIPA Client Error: "+err.Error(),
+		)
 		return
 	}
 

--- a/freeipa/dns_record_resource.go
+++ b/freeipa/dns_record_resource.go
@@ -129,14 +129,24 @@ func (r *DNSRecordResource) Configure(ctx context.Context, req resource.Configur
 		return
 	}
 
-	client, ok := req.ProviderData.(*ipa.Client)
-
+	config, ok := req.ProviderData.(*freeipaProviderModel)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *http.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *freeipaProviderModel, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
+		return
+	}
 
+	p := &freeipaProvider{}
+	client, err := p.NewFreeIPAClient(ctx, config)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Create FreeIPA API Client",
+			"An unexpected error occurred when creating the FreeIPA API client. "+
+				"If the error is not clear, please contact the provider developers.\n\n"+
+				"FreeIPA Client Error: "+err.Error(),
+		)
 		return
 	}
 

--- a/freeipa/dns_server_resource.go
+++ b/freeipa/dns_server_resource.go
@@ -51,14 +51,27 @@ func (r *dnsServer) Configure(ctx context.Context, req resource.ConfigureRequest
 	if req.ProviderData == nil {
 		return
 	}
-	client, ok := req.ProviderData.(*ipa.Client)
+	config, ok := req.ProviderData.(*freeipaProviderModel)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *ipa.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *freeipaProviderModel, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 		return
 	}
+
+	p := &freeipaProvider{}
+	client, err := p.NewFreeIPAClient(ctx, config)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Create FreeIPA API Client",
+			"An unexpected error occurred when creating the FreeIPA API client. "+
+				"If the error is not clear, please contact the provider developers.\n\n"+
+				"FreeIPA Client Error: "+err.Error(),
+		)
+		return
+	}
+
 	r.client = client
 }
 

--- a/freeipa/dns_zone_data_source.go
+++ b/freeipa/dns_zone_data_source.go
@@ -175,14 +175,24 @@ func (r *dnsZoneDataSource) Configure(ctx context.Context, req datasource.Config
 		return
 	}
 
-	client, ok := req.ProviderData.(*ipa.Client)
-
+	config, ok := req.ProviderData.(*freeipaProviderModel)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *http.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *freeipaProviderModel, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
+		return
+	}
 
+	p := &freeipaProvider{}
+	client, err := p.NewFreeIPAClient(ctx, config)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Create FreeIPA API Client",
+			"An unexpected error occurred when creating the FreeIPA API client. "+
+				"If the error is not clear, please contact the provider developers.\n\n"+
+				"FreeIPA Client Error: "+err.Error(),
+		)
 		return
 	}
 

--- a/freeipa/dns_zone_resource.go
+++ b/freeipa/dns_zone_resource.go
@@ -290,14 +290,24 @@ func (r *dnsZone) Configure(ctx context.Context, req resource.ConfigureRequest, 
 		return
 	}
 
-	client, ok := req.ProviderData.(*ipa.Client)
-
+	config, ok := req.ProviderData.(*freeipaProviderModel)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *http.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *freeipaProviderModel, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
+		return
+	}
 
+	p := &freeipaProvider{}
+	client, err := p.NewFreeIPAClient(ctx, config)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Create FreeIPA API Client",
+			"An unexpected error occurred when creating the FreeIPA API client. "+
+				"If the error is not clear, please contact the provider developers.\n\n"+
+				"FreeIPA Client Error: "+err.Error(),
+		)
 		return
 	}
 

--- a/freeipa/group_data_source.go
+++ b/freeipa/group_data_source.go
@@ -147,14 +147,24 @@ func (r *UserGroupDataSource) Configure(ctx context.Context, req datasource.Conf
 		return
 	}
 
-	client, ok := req.ProviderData.(*ipa.Client)
-
+	config, ok := req.ProviderData.(*freeipaProviderModel)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *http.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *freeipaProviderModel, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
+		return
+	}
 
+	p := &freeipaProvider{}
+	client, err := p.NewFreeIPAClient(ctx, config)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Create FreeIPA API Client",
+			"An unexpected error occurred when creating the FreeIPA API client. "+
+				"If the error is not clear, please contact the provider developers.\n\n"+
+				"FreeIPA Client Error: "+err.Error(),
+		)
 		return
 	}
 

--- a/freeipa/group_resource.go
+++ b/freeipa/group_resource.go
@@ -152,14 +152,24 @@ func (r *UserGroupResource) Configure(ctx context.Context, req resource.Configur
 		return
 	}
 
-	client, ok := req.ProviderData.(*ipa.Client)
-
+	config, ok := req.ProviderData.(*freeipaProviderModel)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *http.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *freeipaProviderModel, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
+		return
+	}
 
+	p := &freeipaProvider{}
+	client, err := p.NewFreeIPAClient(ctx, config)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Create FreeIPA API Client",
+			"An unexpected error occurred when creating the FreeIPA API client. "+
+				"If the error is not clear, please contact the provider developers.\n\n"+
+				"FreeIPA Client Error: "+err.Error(),
+		)
 		return
 	}
 

--- a/freeipa/hbac_policy_data_source.go
+++ b/freeipa/hbac_policy_data_source.go
@@ -131,14 +131,24 @@ func (r *HbacPolicyDataSource) Configure(ctx context.Context, req datasource.Con
 		return
 	}
 
-	client, ok := req.ProviderData.(*ipa.Client)
-
+	config, ok := req.ProviderData.(*freeipaProviderModel)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *http.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *freeipaProviderModel, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
+		return
+	}
 
+	p := &freeipaProvider{}
+	client, err := p.NewFreeIPAClient(ctx, config)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Create FreeIPA API Client",
+			"An unexpected error occurred when creating the FreeIPA API client. "+
+				"If the error is not clear, please contact the provider developers.\n\n"+
+				"FreeIPA Client Error: "+err.Error(),
+		)
 		return
 	}
 

--- a/freeipa/hbac_policy_host_membership_resource.go
+++ b/freeipa/hbac_policy_host_membership_resource.go
@@ -149,14 +149,24 @@ func (r *HbacPolicyHostMembershipResource) Configure(ctx context.Context, req re
 		return
 	}
 
-	client, ok := req.ProviderData.(*ipa.Client)
-
+	config, ok := req.ProviderData.(*freeipaProviderModel)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *http.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *freeipaProviderModel, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
+		return
+	}
 
+	p := &freeipaProvider{}
+	client, err := p.NewFreeIPAClient(ctx, config)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Create FreeIPA API Client",
+			"An unexpected error occurred when creating the FreeIPA API client. "+
+				"If the error is not clear, please contact the provider developers.\n\n"+
+				"FreeIPA Client Error: "+err.Error(),
+		)
 		return
 	}
 

--- a/freeipa/hbac_policy_resource.go
+++ b/freeipa/hbac_policy_resource.go
@@ -113,14 +113,24 @@ func (r *HbacPolicyResource) Configure(ctx context.Context, req resource.Configu
 		return
 	}
 
-	client, ok := req.ProviderData.(*ipa.Client)
-
+	config, ok := req.ProviderData.(*freeipaProviderModel)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *http.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *freeipaProviderModel, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
+		return
+	}
 
+	p := &freeipaProvider{}
+	client, err := p.NewFreeIPAClient(ctx, config)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Create FreeIPA API Client",
+			"An unexpected error occurred when creating the FreeIPA API client. "+
+				"If the error is not clear, please contact the provider developers.\n\n"+
+				"FreeIPA Client Error: "+err.Error(),
+		)
 		return
 	}
 

--- a/freeipa/hbac_policy_service_membership_resource .go
+++ b/freeipa/hbac_policy_service_membership_resource .go
@@ -149,14 +149,24 @@ func (r *HbacPolicyServiceMembershipResource) Configure(ctx context.Context, req
 		return
 	}
 
-	client, ok := req.ProviderData.(*ipa.Client)
-
+	config, ok := req.ProviderData.(*freeipaProviderModel)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *http.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *freeipaProviderModel, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
+		return
+	}
 
+	p := &freeipaProvider{}
+	client, err := p.NewFreeIPAClient(ctx, config)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Create FreeIPA API Client",
+			"An unexpected error occurred when creating the FreeIPA API client. "+
+				"If the error is not clear, please contact the provider developers.\n\n"+
+				"FreeIPA Client Error: "+err.Error(),
+		)
 		return
 	}
 

--- a/freeipa/hbac_policy_user_membership_resource.go
+++ b/freeipa/hbac_policy_user_membership_resource.go
@@ -149,14 +149,24 @@ func (r *HbacPolicyUserMembershipResource) Configure(ctx context.Context, req re
 		return
 	}
 
-	client, ok := req.ProviderData.(*ipa.Client)
-
+	config, ok := req.ProviderData.(*freeipaProviderModel)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *http.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *freeipaProviderModel, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
+		return
+	}
 
+	p := &freeipaProvider{}
+	client, err := p.NewFreeIPAClient(ctx, config)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Create FreeIPA API Client",
+			"An unexpected error occurred when creating the FreeIPA API client. "+
+				"If the error is not clear, please contact the provider developers.\n\n"+
+				"FreeIPA Client Error: "+err.Error(),
+		)
 		return
 	}
 

--- a/freeipa/host_data_source.go
+++ b/freeipa/host_data_source.go
@@ -182,14 +182,24 @@ func (r *HostDataSource) Configure(ctx context.Context, req datasource.Configure
 		return
 	}
 
-	client, ok := req.ProviderData.(*ipa.Client)
-
+	config, ok := req.ProviderData.(*freeipaProviderModel)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *http.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *freeipaProviderModel, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
+		return
+	}
 
+	p := &freeipaProvider{}
+	client, err := p.NewFreeIPAClient(ctx, config)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Create FreeIPA API Client",
+			"An unexpected error occurred when creating the FreeIPA API client. "+
+				"If the error is not clear, please contact the provider developers.\n\n"+
+				"FreeIPA Client Error: "+err.Error(),
+		)
 		return
 	}
 

--- a/freeipa/host_hostgroup_membership_resource.go
+++ b/freeipa/host_hostgroup_membership_resource.go
@@ -153,14 +153,24 @@ func (r *HostGroupMembership) Configure(ctx context.Context, req resource.Config
 		return
 	}
 
-	client, ok := req.ProviderData.(*ipa.Client)
-
+	config, ok := req.ProviderData.(*freeipaProviderModel)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *http.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *freeipaProviderModel, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
+		return
+	}
 
+	p := &freeipaProvider{}
+	client, err := p.NewFreeIPAClient(ctx, config)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Create FreeIPA API Client",
+			"An unexpected error occurred when creating the FreeIPA API client. "+
+				"If the error is not clear, please contact the provider developers.\n\n"+
+				"FreeIPA Client Error: "+err.Error(),
+		)
 		return
 	}
 

--- a/freeipa/host_resource.go
+++ b/freeipa/host_resource.go
@@ -200,14 +200,24 @@ func (r *HostResource) Configure(ctx context.Context, req resource.ConfigureRequ
 		return
 	}
 
-	client, ok := req.ProviderData.(*ipa.Client)
-
+	config, ok := req.ProviderData.(*freeipaProviderModel)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *http.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *freeipaProviderModel, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
+		return
+	}
 
+	p := &freeipaProvider{}
+	client, err := p.NewFreeIPAClient(ctx, config)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Create FreeIPA API Client",
+			"An unexpected error occurred when creating the FreeIPA API client. "+
+				"If the error is not clear, please contact the provider developers.\n\n"+
+				"FreeIPA Client Error: "+err.Error(),
+		)
 		return
 	}
 

--- a/freeipa/hostgroup_data_source.go
+++ b/freeipa/hostgroup_data_source.go
@@ -136,14 +136,24 @@ func (r *HostGroupDataSource) Configure(ctx context.Context, req datasource.Conf
 		return
 	}
 
-	client, ok := req.ProviderData.(*ipa.Client)
-
+	config, ok := req.ProviderData.(*freeipaProviderModel)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *http.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *freeipaProviderModel, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
+		return
+	}
 
+	p := &freeipaProvider{}
+	client, err := p.NewFreeIPAClient(ctx, config)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Create FreeIPA API Client",
+			"An unexpected error occurred when creating the FreeIPA API client. "+
+				"If the error is not clear, please contact the provider developers.\n\n"+
+				"FreeIPA Client Error: "+err.Error(),
+		)
 		return
 	}
 

--- a/freeipa/hostgroup_resource .go
+++ b/freeipa/hostgroup_resource .go
@@ -90,14 +90,24 @@ func (r *HostGroupResource) Configure(ctx context.Context, req resource.Configur
 		return
 	}
 
-	client, ok := req.ProviderData.(*ipa.Client)
-
+	config, ok := req.ProviderData.(*freeipaProviderModel)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *http.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *freeipaProviderModel, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
+		return
+	}
 
+	p := &freeipaProvider{}
+	client, err := p.NewFreeIPAClient(ctx, config)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Create FreeIPA API Client",
+			"An unexpected error occurred when creating the FreeIPA API client. "+
+				"If the error is not clear, please contact the provider developers.\n\n"+
+				"FreeIPA Client Error: "+err.Error(),
+		)
 		return
 	}
 

--- a/freeipa/provider.go
+++ b/freeipa/provider.go
@@ -187,22 +187,13 @@ func (p *freeipaProvider) Configure(ctx context.Context, req provider.ConfigureR
 		return
 	}
 
-	// Create a new FreeIPA client using the configuration values
-	client, err := p.NewFreeIPAClient(ctx, &config)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to Create FreeIPA API Client",
-			"An unexpected error occurred when creating the FreeIPA API client. "+
-				"If the error is not clear, please contact the provider developers.\n\n"+
-				"FreeIPA Client Error: "+err.Error(),
-		)
-		return
-	}
-
-	// Make the FreeIPA client available during DataSource and Resource
-	// type Configure methods.
-	resp.DataSourceData = client
-	resp.ResourceData = client
+	// Pass the resolved configuration (not a connected client) to
+	// DataSource and Resource type Configure methods. Each resource/data
+	// source creates its own FreeIPA client lazily, only when it is
+	// actually used, so declaring the provider without using any of its
+	// resources does not require a reachable FreeIPA host.
+	resp.DataSourceData = &config
+	resp.ResourceData = &config
 }
 
 // Client creates a FreeIPA client scoped to the global API

--- a/freeipa/sudo_cmd_resource.go
+++ b/freeipa/sudo_cmd_resource.go
@@ -90,14 +90,24 @@ func (r *SudoCmdResource) Configure(ctx context.Context, req resource.ConfigureR
 		return
 	}
 
-	client, ok := req.ProviderData.(*ipa.Client)
-
+	config, ok := req.ProviderData.(*freeipaProviderModel)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *http.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *freeipaProviderModel, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
+		return
+	}
 
+	p := &freeipaProvider{}
+	client, err := p.NewFreeIPAClient(ctx, config)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Create FreeIPA API Client",
+			"An unexpected error occurred when creating the FreeIPA API client. "+
+				"If the error is not clear, please contact the provider developers.\n\n"+
+				"FreeIPA Client Error: "+err.Error(),
+		)
 		return
 	}
 

--- a/freeipa/sudo_cmdgroup_data_source.go
+++ b/freeipa/sudo_cmdgroup_data_source.go
@@ -81,14 +81,24 @@ func (r *SudoCmdGroupDataSource) Configure(ctx context.Context, req datasource.C
 		return
 	}
 
-	client, ok := req.ProviderData.(*ipa.Client)
-
+	config, ok := req.ProviderData.(*freeipaProviderModel)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *http.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *freeipaProviderModel, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
+		return
+	}
 
+	p := &freeipaProvider{}
+	client, err := p.NewFreeIPAClient(ctx, config)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Create FreeIPA API Client",
+			"An unexpected error occurred when creating the FreeIPA API client. "+
+				"If the error is not clear, please contact the provider developers.\n\n"+
+				"FreeIPA Client Error: "+err.Error(),
+		)
 		return
 	}
 

--- a/freeipa/sudo_cmdgroup_membership_resource.go
+++ b/freeipa/sudo_cmdgroup_membership_resource.go
@@ -118,14 +118,24 @@ func (r *SudoCmdGroupMembershipResource) Configure(ctx context.Context, req reso
 		return
 	}
 
-	client, ok := req.ProviderData.(*ipa.Client)
-
+	config, ok := req.ProviderData.(*freeipaProviderModel)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *http.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *freeipaProviderModel, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
+		return
+	}
 
+	p := &freeipaProvider{}
+	client, err := p.NewFreeIPAClient(ctx, config)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Create FreeIPA API Client",
+			"An unexpected error occurred when creating the FreeIPA API client. "+
+				"If the error is not clear, please contact the provider developers.\n\n"+
+				"FreeIPA Client Error: "+err.Error(),
+		)
 		return
 	}
 

--- a/freeipa/sudo_cmdgroup_resource.go
+++ b/freeipa/sudo_cmdgroup_resource.go
@@ -90,14 +90,24 @@ func (r *SudoCmdGroupResource) Configure(ctx context.Context, req resource.Confi
 		return
 	}
 
-	client, ok := req.ProviderData.(*ipa.Client)
-
+	config, ok := req.ProviderData.(*freeipaProviderModel)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *http.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *freeipaProviderModel, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
+		return
+	}
 
+	p := &freeipaProvider{}
+	client, err := p.NewFreeIPAClient(ctx, config)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Create FreeIPA API Client",
+			"An unexpected error occurred when creating the FreeIPA API client. "+
+				"If the error is not clear, please contact the provider developers.\n\n"+
+				"FreeIPA Client Error: "+err.Error(),
+		)
 		return
 	}
 

--- a/freeipa/sudo_rule_allowcmd_membership_resource.go
+++ b/freeipa/sudo_rule_allowcmd_membership_resource.go
@@ -149,14 +149,24 @@ func (r *SudoRuleAllowCmdMembershipResource) Configure(ctx context.Context, req 
 		return
 	}
 
-	client, ok := req.ProviderData.(*ipa.Client)
-
+	config, ok := req.ProviderData.(*freeipaProviderModel)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *http.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *freeipaProviderModel, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
+		return
+	}
 
+	p := &freeipaProvider{}
+	client, err := p.NewFreeIPAClient(ctx, config)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Create FreeIPA API Client",
+			"An unexpected error occurred when creating the FreeIPA API client. "+
+				"If the error is not clear, please contact the provider developers.\n\n"+
+				"FreeIPA Client Error: "+err.Error(),
+		)
 		return
 	}
 

--- a/freeipa/sudo_rule_data_source.go
+++ b/freeipa/sudo_rule_data_source.go
@@ -176,14 +176,24 @@ func (r *SudoRuleDataSource) Configure(ctx context.Context, req datasource.Confi
 		return
 	}
 
-	client, ok := req.ProviderData.(*ipa.Client)
-
+	config, ok := req.ProviderData.(*freeipaProviderModel)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *http.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *freeipaProviderModel, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
+		return
+	}
 
+	p := &freeipaProvider{}
+	client, err := p.NewFreeIPAClient(ctx, config)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Create FreeIPA API Client",
+			"An unexpected error occurred when creating the FreeIPA API client. "+
+				"If the error is not clear, please contact the provider developers.\n\n"+
+				"FreeIPA Client Error: "+err.Error(),
+		)
 		return
 	}
 

--- a/freeipa/sudo_rule_denycmd_membership_resource.go
+++ b/freeipa/sudo_rule_denycmd_membership_resource.go
@@ -149,14 +149,24 @@ func (r *SudoRuleDenyCmdMembershipResource) Configure(ctx context.Context, req r
 		return
 	}
 
-	client, ok := req.ProviderData.(*ipa.Client)
-
+	config, ok := req.ProviderData.(*freeipaProviderModel)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *http.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *freeipaProviderModel, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
+		return
+	}
 
+	p := &freeipaProvider{}
+	client, err := p.NewFreeIPAClient(ctx, config)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Create FreeIPA API Client",
+			"An unexpected error occurred when creating the FreeIPA API client. "+
+				"If the error is not clear, please contact the provider developers.\n\n"+
+				"FreeIPA Client Error: "+err.Error(),
+		)
 		return
 	}
 

--- a/freeipa/sudo_rule_host_membership_resource.go
+++ b/freeipa/sudo_rule_host_membership_resource.go
@@ -149,14 +149,24 @@ func (r *SudoRuleHostMembershipResource) Configure(ctx context.Context, req reso
 		return
 	}
 
-	client, ok := req.ProviderData.(*ipa.Client)
-
+	config, ok := req.ProviderData.(*freeipaProviderModel)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *http.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *freeipaProviderModel, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
+		return
+	}
 
+	p := &freeipaProvider{}
+	client, err := p.NewFreeIPAClient(ctx, config)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Create FreeIPA API Client",
+			"An unexpected error occurred when creating the FreeIPA API client. "+
+				"If the error is not clear, please contact the provider developers.\n\n"+
+				"FreeIPA Client Error: "+err.Error(),
+		)
 		return
 	}
 

--- a/freeipa/sudo_rule_option_resource.go
+++ b/freeipa/sudo_rule_option_resource.go
@@ -94,14 +94,24 @@ func (r *SudoRuleOptionResource) Configure(ctx context.Context, req resource.Con
 		return
 	}
 
-	client, ok := req.ProviderData.(*ipa.Client)
-
+	config, ok := req.ProviderData.(*freeipaProviderModel)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *http.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *freeipaProviderModel, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
+		return
+	}
 
+	p := &freeipaProvider{}
+	client, err := p.NewFreeIPAClient(ctx, config)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Create FreeIPA API Client",
+			"An unexpected error occurred when creating the FreeIPA API client. "+
+				"If the error is not clear, please contact the provider developers.\n\n"+
+				"FreeIPA Client Error: "+err.Error(),
+		)
 		return
 	}
 

--- a/freeipa/sudo_rule_resource.go
+++ b/freeipa/sudo_rule_resource.go
@@ -128,14 +128,24 @@ func (r *SudoRuleResource) Configure(ctx context.Context, req resource.Configure
 		return
 	}
 
-	client, ok := req.ProviderData.(*ipa.Client)
-
+	config, ok := req.ProviderData.(*freeipaProviderModel)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *http.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *freeipaProviderModel, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
+		return
+	}
 
+	p := &freeipaProvider{}
+	client, err := p.NewFreeIPAClient(ctx, config)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Create FreeIPA API Client",
+			"An unexpected error occurred when creating the FreeIPA API client. "+
+				"If the error is not clear, please contact the provider developers.\n\n"+
+				"FreeIPA Client Error: "+err.Error(),
+		)
 		return
 	}
 

--- a/freeipa/sudo_rule_runasgroup_membership_resource.go
+++ b/freeipa/sudo_rule_runasgroup_membership_resource.go
@@ -118,14 +118,24 @@ func (r *SudoRuleRunAsGroupMembershipResource) Configure(ctx context.Context, re
 		return
 	}
 
-	client, ok := req.ProviderData.(*ipa.Client)
-
+	config, ok := req.ProviderData.(*freeipaProviderModel)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *http.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *freeipaProviderModel, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
+		return
+	}
 
+	p := &freeipaProvider{}
+	client, err := p.NewFreeIPAClient(ctx, config)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Create FreeIPA API Client",
+			"An unexpected error occurred when creating the FreeIPA API client. "+
+				"If the error is not clear, please contact the provider developers.\n\n"+
+				"FreeIPA Client Error: "+err.Error(),
+		)
 		return
 	}
 

--- a/freeipa/sudo_rule_runasuser_membership_resource.go
+++ b/freeipa/sudo_rule_runasuser_membership_resource.go
@@ -118,14 +118,24 @@ func (r *SudoRuleRunAsUserMembershipResource) Configure(ctx context.Context, req
 		return
 	}
 
-	client, ok := req.ProviderData.(*ipa.Client)
-
+	config, ok := req.ProviderData.(*freeipaProviderModel)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *http.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *freeipaProviderModel, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
+		return
+	}
 
+	p := &freeipaProvider{}
+	client, err := p.NewFreeIPAClient(ctx, config)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Create FreeIPA API Client",
+			"An unexpected error occurred when creating the FreeIPA API client. "+
+				"If the error is not clear, please contact the provider developers.\n\n"+
+				"FreeIPA Client Error: "+err.Error(),
+		)
 		return
 	}
 

--- a/freeipa/sudo_rule_user_membership_resource.go
+++ b/freeipa/sudo_rule_user_membership_resource.go
@@ -149,14 +149,24 @@ func (r *SudoRuleUserMembershipResource) Configure(ctx context.Context, req reso
 		return
 	}
 
-	client, ok := req.ProviderData.(*ipa.Client)
-
+	config, ok := req.ProviderData.(*freeipaProviderModel)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *http.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *freeipaProviderModel, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
+		return
+	}
 
+	p := &freeipaProvider{}
+	client, err := p.NewFreeIPAClient(ctx, config)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Create FreeIPA API Client",
+			"An unexpected error occurred when creating the FreeIPA API client. "+
+				"If the error is not clear, please contact the provider developers.\n\n"+
+				"FreeIPA Client Error: "+err.Error(),
+		)
 		return
 	}
 

--- a/freeipa/sysaccount_data_source.go
+++ b/freeipa/sysaccount_data_source.go
@@ -87,14 +87,24 @@ func (r *SysAccountSource) Configure(ctx context.Context, req datasource.Configu
 		return
 	}
 
-	client, ok := req.ProviderData.(*ipa.Client)
-
+	config, ok := req.ProviderData.(*freeipaProviderModel)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *http.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *freeipaProviderModel, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
+		return
+	}
 
+	p := &freeipaProvider{}
+	client, err := p.NewFreeIPAClient(ctx, config)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Create FreeIPA API Client",
+			"An unexpected error occurred when creating the FreeIPA API client. "+
+				"If the error is not clear, please contact the provider developers.\n\n"+
+				"FreeIPA Client Error: "+err.Error(),
+		)
 		return
 	}
 

--- a/freeipa/sysaccount_resource.go
+++ b/freeipa/sysaccount_resource.go
@@ -126,14 +126,24 @@ func (r *SysAccountResource) Configure(ctx context.Context, req resource.Configu
 		return
 	}
 
-	client, ok := req.ProviderData.(*ipa.Client)
-
+	config, ok := req.ProviderData.(*freeipaProviderModel)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *http.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *freeipaProviderModel, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
+		return
+	}
 
+	p := &freeipaProvider{}
+	client, err := p.NewFreeIPAClient(ctx, config)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Create FreeIPA API Client",
+			"An unexpected error occurred when creating the FreeIPA API client. "+
+				"If the error is not clear, please contact the provider developers.\n\n"+
+				"FreeIPA Client Error: "+err.Error(),
+		)
 		return
 	}
 

--- a/freeipa/user_data_source.go
+++ b/freeipa/user_data_source.go
@@ -302,14 +302,24 @@ func (r *UserDataSource) Configure(ctx context.Context, req datasource.Configure
 		return
 	}
 
-	client, ok := req.ProviderData.(*ipa.Client)
-
+	config, ok := req.ProviderData.(*freeipaProviderModel)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *http.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *freeipaProviderModel, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
+		return
+	}
 
+	p := &freeipaProvider{}
+	client, err := p.NewFreeIPAClient(ctx, config)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Create FreeIPA API Client",
+			"An unexpected error occurred when creating the FreeIPA API client. "+
+				"If the error is not clear, please contact the provider developers.\n\n"+
+				"FreeIPA Client Error: "+err.Error(),
+		)
 		return
 	}
 

--- a/freeipa/user_group_membership_resource.go
+++ b/freeipa/user_group_membership_resource.go
@@ -200,14 +200,24 @@ func (r *userGroupMembership) Configure(ctx context.Context, req resource.Config
 		return
 	}
 
-	client, ok := req.ProviderData.(*ipa.Client)
-
+	config, ok := req.ProviderData.(*freeipaProviderModel)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *http.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *freeipaProviderModel, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
+		return
+	}
 
+	p := &freeipaProvider{}
+	client, err := p.NewFreeIPAClient(ctx, config)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Create FreeIPA API Client",
+			"An unexpected error occurred when creating the FreeIPA API client. "+
+				"If the error is not clear, please contact the provider developers.\n\n"+
+				"FreeIPA Client Error: "+err.Error(),
+		)
 		return
 	}
 

--- a/freeipa/user_resource.go
+++ b/freeipa/user_resource.go
@@ -365,14 +365,24 @@ func (r *UserResource) Configure(ctx context.Context, req resource.ConfigureRequ
 		return
 	}
 
-	client, ok := req.ProviderData.(*ipa.Client)
-
+	config, ok := req.ProviderData.(*freeipaProviderModel)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *http.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *freeipaProviderModel, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
+		return
+	}
 
+	p := &freeipaProvider{}
+	client, err := p.NewFreeIPAClient(ctx, config)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Create FreeIPA API Client",
+			"An unexpected error occurred when creating the FreeIPA API client. "+
+				"If the error is not clear, please contact the provider developers.\n\n"+
+				"FreeIPA Client Error: "+err.Error(),
+		)
 		return
 	}
 


### PR DESCRIPTION
Lazy-loads the IPA client initialization to avoid early network calls.

Closes #106